### PR TITLE
Allow axes to go negative

### DIFF
--- a/src/areachart.jsx
+++ b/src/areachart.jsx
@@ -6,6 +6,7 @@ var common = require('./common');
 var Chart = common.Chart;
 var XAxis = common.XAxis;
 var YAxis = common.YAxis;
+var _ = require('lodash');
 
 var Area = React.createClass({
 

--- a/src/areachart.jsx
+++ b/src/areachart.jsx
@@ -90,7 +90,8 @@ var AreaChart = React.createClass({
     var yScale = d3.scale.linear()
       .range([props.height, 0]);
 
-    yScale.domain([0, d3.max(props.data, function(d) { return d.value; })]);
+    var values = _.pluck(props.data, 'value');
+    yScale.domain([d3.min([d3.min(values), 0]), d3.max(values)]);
 
     var margin = {top: 20, right: 20, bottom: 30, left: 50};
 

--- a/src/barchart.jsx
+++ b/src/barchart.jsx
@@ -110,7 +110,7 @@ var BarChart = React.createClass({
     var topBottomMargins = margins.top + margins.bottom;
 
     var yScale = d3.scale.linear()
-      .domain([0, d3.max(values)])
+      .domain([d3.min([d3.min(values), 0]), d3.max(values)])
       .range([this.props.height - topBottomMargins, 0]);
 
     var xScale = d3.scale.ordinal()

--- a/src/linechart.jsx
+++ b/src/linechart.jsx
@@ -6,6 +6,8 @@ var common = require('./common');
 var Chart = common.Chart;
 var XAxis = common.XAxis;
 var YAxis = common.YAxis;
+var _ = require('lodash');
+
 
 var Line = React.createClass({
 
@@ -134,28 +136,16 @@ var LineChart = React.createClass({
 
   _calculateScales: function(props, chartWidth, chartHeight) {
 
-    var maxY = 0,
-        maxX = 0;
-
-    for(var series in props.data) {
-      var seriesMaxY = d3.max(props.data[series], function(d) {
-        return d.y;
-      });
-
-      var seriesMaxX = d3.max(props.data[series], function(d) {
-        return d.x;
-      });
-
-      maxX = (seriesMaxX > maxX) ? seriesMaxX : maxX;
-      maxY = (seriesMaxY > maxY) ? seriesMaxY : maxY;
-    }
+    var allValues = _.flatten(_.values(this.props.data), true);
+    var xValues = _.pluck(allValues, 'x');
+    var yValues = _.pluck(allValues, 'y');
 
     var xScale = d3.scale.linear()
-      .domain([0, maxX])
+      .domain([d3.min([d3.min(xValues), 0]), d3.max(xValues)])
       .range([0, chartWidth]);
 
     var yScale = d3.scale.linear()
-      .domain([0, maxY])
+      .domain([d3.min([d3.min(yValues), 0]), d3.max(yValues)])
       .range([chartHeight, 0]);
 
     return {xScale: xScale, yScale: yScale};


### PR DESCRIPTION
This change preserves the linechart's behavior for data consisting of only positive values – the axes will still start at 0.  But for data with negative values, the axis will begin at the lowest negative value (see x-axis of image below).  What do you think?

I'm happy to add a test, but since the axes are not rendered by React, the ticks aren't found by the TestUtils methods.

![screen shot 2015-01-23 at 11 21 24 am](https://cloud.githubusercontent.com/assets/1096006/5881012/088bf0dc-a2f2-11e4-9a90-93199233c665.png)
