### PR TITLE
Fixes bug with xAsisClassSelect

### DIFF
--- a/src/common/axes.jsx
+++ b/src/common/axes.jsx
@@ -63,13 +63,13 @@ exports.XAxis = React.createClass({
       .call(xAxis);
 
     // Style each of the tick lines
-    d3.select(xAxisClassSelect)
+    d3.selectAll(xAxisClassSelect)
       .selectAll('line')
       .attr("shape-rendering", "crispEdges")
       .attr("stroke", props.tickStroke);
 
     // Style the main axis line
-    d3.select(xAxisClassSelect)
+    d3.selectAll(xAxisClassSelect)
       .select('path')
       .attr("shape-rendering", "crispEdges")
       .attr("fill", props.fill)


### PR DESCRIPTION
Need to selectAll on xAxisClassSelect (as you are doing for the YAxis). This selection only updates the first instance of xAxis but fails if you have multiples of the same chart type on a page.