### PR TITLE
I'm doing a little cleanup on the build scripts. The most notable issue ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ npm-debug.log
 
 # Build directory
 build/
+
+#intellij
+.idea/

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "env": "env",
     "watch": "npm run docs && watchify -o build/public/js/main.js docs/examples/main.js --extension='.jsx' & nodemon server.js",
     "docs": "mkdir -p build && cp -r dist/public build && browserify -o build/public/js/main.js --extension='.jsx' docs/examples/main.js",
-    "minified": "npm run build && NODE_ENV=production browserify -t [ reactify --es6 ] --standalone rd3 ./build/cjs/index.js | uglifyjs -c > dist/public/js/react-d3.min.js",
+    "minified": "npm run release && NODE_ENV=production browserify -t [ reactify --es6 ] --standalone rd3 ./build/cjs/index.js | uglifyjs -c > dist/public/js/react-d3.min.js",
     "release": "mkdir -p ./build/cjs && cp *.md ./build/cjs && cp .npmignore ./build/cjs && node scripts/build.js && jsx --harmony -x jsx ./src ./build/cjs && jsx --harmony ./src ./build/cjs",
-    "clean": "rm -f ./build/cjs/*.js",
+    "clean": "rm -rf ./build/cjs",
     "lint": "jsxhint src/* tests/* || true",
     "test": "karma start karma.conf.js"
   },


### PR DESCRIPTION
...is that 'build' was changed to 'release' and the minified script wasn't updated to accomodate that. It was still running "npm run build" which doesn't do anything. I also updated clean so it removes the build/cjs directory since release will make the directory and populate it. Previously it would clean up only javascript files directly inside of dist/cjs/ and not, for example, dist/cjs/util/index.js or any of the .md that release copies in.