### PR TITLE
updating the demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Then, import into your ReactJS project:
 
 `var rd3 = require('react-d3');`
 
-The charts are then available under the `rd3` namespace, which you can then use as shown on the [demonstration page](http://esbullington.github.io/react-d3):
+The charts are then available under the `rd3` namespace, which you can then use as shown on the [demonstration page](http://esbullington.github.io/react-d3-website/):
 
 ### Available Charts
 


### PR DESCRIPTION
The old demo link in the README is pointing to a page with out of date instructions. Changing the link to point to a more current demo page.