### PR TITLE
Gulp improvements

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,8 @@ var gulp = require('gulp'),
   source = require('vinyl-source-stream'),
   buffer = require('vinyl-buffer'),
   browserSync = require('browser-sync'),
-  merge = require('merge-stream');
+  merge = require('merge-stream'),
+  chalk = require('chalk');
 
 console.timeEnd('Loading plugins');
 
@@ -84,6 +85,10 @@ function compileJS(entry) {
 
 function bundleShare(b) {
   return b.bundle()
+    .on('error', function(err){
+      console.log(chalk.red(err.toString()));
+      this.end();
+    })
     .pipe(source('main.js')) // TODO change this to react-d3.js after the npm run scripts are retired and changing docs/public/index.html to use react-d3.js instead of main.js
     .pipe(buffer())
     .pipe(plugins.sourcemaps.init({loadMaps: true}))

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "browserify": "~8.1.3",
     "browserify-global-shim": "^1.0.0",
     "chai": "^2.0.0",
+    "chalk": "^0.5.1",
     "del": "^1.1.1",
     "glob": "^4.4.0",
     "gulp": "^3.8.7",


### PR DESCRIPTION
- Stopped build crashing on browserify errors, which is really annoying when watching
- Added chalk for log colors