### PR TITLE
allowed linechart series to define their own x and y accessors

### DIFF
--- a/src/linechart.jsx
+++ b/src/linechart.jsx
@@ -386,8 +386,8 @@ var LineChart = exports.LineChart = React.createClass({
             fill={props.colors(idx)}
             pointRadius={props.pointRadius}
             key={series.name}
-            xAccessor={props.xAccessor}
-            yAccessor={props.yAccessor}
+            xAccessor={series.xAccessor || props.xAccessor}
+            yAccessor={series.yAccessor || props.yAccessor}
             interpolationType={interpolationType}
             displayDataPoints={props.displayDataPoints}
           />

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -62,6 +62,7 @@ exports.flattenData = (data, xAccessor, yAccessor) => {
   data.forEach( (series) => {
     series.values.forEach( (item, idx) => {
 
+      xAccessor = series.xAccessor || xAccessor;
       var x = xAccessor(item);
 
       // Check for NaN since d3's Voronoi cannot handle NaN values
@@ -72,6 +73,7 @@ exports.flattenData = (data, xAccessor, yAccessor) => {
       }
       xValues.push(x);
 
+      yAccessor = series.yAccessor || yAccessor;
       var y = yAccessor(item);
       // when yAccessor returns an object (as in the case of candlestick)
       // iterate over the keys and push all the values to yValues array


### PR DESCRIPTION
I have data that looks like this: 
```javascript[
[
  {
    month: 0
    value1: 1234,
    value2: 4567
  },
  {
    month: 1
    value1: 7890,
    value2: 7410
  },...
]
```
I would like to be able to not have to preprocess it into separate series in order to graph `value1` vs `value2`. This change allows a `yAccessor` or `xAccessor` to be defined in the series that would override the default selector. I have modified only the LineChart, but I imagine this would impact all of the charts to be done properly. I can modify the others as well if this is the right approach.