### PR TITLE
Fixed syntax error in piechart/arc.jsx that broke the build

### DIFF
--- a/src/piechart/Arc.jsx
+++ b/src/piechart/Arc.jsx
@@ -55,8 +55,8 @@ module.exports = React.createClass({
           transform={rotate}
           style={{
             'fill': props.labelTextFill,
-            'strokeWidth': 2,
-          }}>
+            'strokeWidth': 2
+          }}
         >
         </line>
         <text


### PR DESCRIPTION
Hi

I noticed this small syntax error that stopped gulp from doing it's thing, and also broke the tests.

Cheers
Graham