### PR TITLE
Add browserify transform field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
     "watch": "gulp watch",
     "minified": "gulp release && npm run build && NODE_ENV=production browserify -t [ reactify --es6 ] --standalone rd3 ./build/cjs/index.js | uglifyjs -c > dist/public/js/react-d3.min.js"
   },
+  "browserify": {
+    "transform": [
+      ["reactify", { "es6": true } ]
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/esbullington/react-d3.git"


### PR DESCRIPTION
Browserifying a project that depends on react-d3 from a local checkout (via `npm link`) currently fails with parse errors due to the jsx/es6 syntax in source files. This PR adds a [transform](https://github.com/substack/browserify-handbook#browserifytransform-field) field to package.json, which makes browserify transpile the source code on the fly in cases like this.

This is super useful for debugging purposes and should cause no additional overhead when react-d3 is installed from npm, as a different package.json is shipped with the npm release.