### PR TITLE
Conforms area chart to use index instead of name for selecting color

### DIFF
--- a/src/areachart/DataSeries.jsx
+++ b/src/areachart/DataSeries.jsx
@@ -18,7 +18,7 @@ module.exports = React.createClass({
     var path = area(props.data);
 
     return (
-      <Area fill={props.colors(props.name)} path={path} />
+      <Area fill={props.colors(props.index)} path={path} />
     );
   }
 


### PR DESCRIPTION
Use index instead of name in line with convention so that the legend corresponds to the chart.