### PR TITLE
Adds showInnerLabel and showOuterLabel props to PieChart

### DIFF
--- a/src/piechart/Arc.jsx
+++ b/src/piechart/Arc.jsx
@@ -16,13 +16,17 @@ module.exports = React.createClass({
     innerRadius: React.PropTypes.number,
     outerRadius: React.PropTypes.number,
     labelTextFill: React.PropTypes.string,
-    valueTextFill: React.PropTypes.string
+    valueTextFill: React.PropTypes.string,
+    showInnerLabels: React.PropTypes.bool,
+    showOuterLabels: React.PropTypes.bool
   },
 
   getDefaultProps() {
     return {
       labelTextFill: 'black',
-      valueTextFill: 'white'
+      valueTextFill: 'white',
+      showInnerLabels: true,
+      showOuterLabels: true,
     };
   },
 
@@ -45,12 +49,9 @@ module.exports = React.createClass({
     // make value text can be formatted
     var formattedValue = props.valueTextFormatter(props.value);
 
-    return (
-      <g className='rd3-piechart-arc' >
-        <path
-          d={arc()}
-          fill={props.fill}
-        />
+    var outerLabels = null;
+    if (this.props.showOuterLabels) {
+      outerLabels = [
         <line
           x1='0'
           x2='0'
@@ -62,8 +63,9 @@ module.exports = React.createClass({
             'fill': props.labelTextFill,
             'strokeWidth': 2
           }}
-        >
+          >
         </line>
+        ,
         <text
           className='rd3-piechart-label'
           transform={t}
@@ -75,6 +77,12 @@ module.exports = React.createClass({
           }}>
           {props.label}
         </text>
+      ]
+    }
+
+    var innerLabels = null;
+    if (this.props.showInnerLabels) {
+      innerLabels = (
         <text
           className='rd3-piechart-value'
           transform={`translate(${arc.centroid()})`}
@@ -86,7 +94,18 @@ module.exports = React.createClass({
           }}>
           { formattedValue }
         </text>
+      );
+    }
+
+    return (
+      <g className='rd3-piechart-arc' >
+        <path
+          d={arc()}
+          fill={props.fill}
+        />
+        {outerLabels}
+        {innerLabels}
       </g>
     );
-  }
+  },
 });

--- a/src/piechart/DataSeries.jsx
+++ b/src/piechart/DataSeries.jsx
@@ -14,7 +14,9 @@ module.exports = React.createClass({
     data: React.PropTypes.array,
     innerRadius: React.PropTypes.number,
     radius: React.PropTypes.number,
-    colors: React.PropTypes.func
+    colors: React.PropTypes.func,
+    showInnerLabels: React.PropTypes.bool,
+    showOuterLabels: React.PropTypes.bool
   },
 
   getDefaultProps() {
@@ -50,6 +52,8 @@ module.exports = React.createClass({
           value={props.data[idx]}
           key={idx}
           width={props.width}
+          showInnerLabels={props.showInnerLabels}
+          showOuterLabels={props.showOuterLabels}
         />
       );
     });

--- a/src/piechart/PieChart.jsx
+++ b/src/piechart/PieChart.jsx
@@ -18,13 +18,16 @@ module.exports = React.createClass({
 
   propTypes: {
     radius: React.PropTypes.number,
+    data: React.PropTypes.array,
     cx: React.PropTypes.number,
     cy: React.PropTypes.number,
     labelTextFill: React.PropTypes.string,
     valueTextFill: React.PropTypes.string,
     valueTextFormatter: React.PropTypes.func,
     colors: React.PropTypes.func,
-    title: React.PropTypes.string
+    title: React.PropTypes.string,
+    showInnerLabels: React.PropTypes.bool,
+    showOuterLabels: React.PropTypes.bool
   },
 
   render: function() {
@@ -53,6 +56,8 @@ module.exports = React.createClass({
             height={props.height}
             radius={props.radius}
             innerRadius={props.innerRadius}
+            showInnerLabels={props.showInnerLabels}
+            showOuterLabels={props.showOuterLabels}
           />
         </g>
       </Chart>

--- a/tests/piechart-tests.js
+++ b/tests/piechart-tests.js
@@ -46,4 +46,28 @@ describe('PieChart', function() {
     expect(formattedValueTexts[0].getDOMNode().textContent).to.contain('$');
     
   });
+
+  it('doesnt show inner labels if not specified', function() {
+    var piechart = TestUtils.renderIntoDocument(
+      <PieChart 
+        data={data} width={400} height={200} 
+        showInnerLabels={false}
+      />
+    );
+    
+    var labels = TestUtils.scryRenderedDOMComponentsWithClass(piechart, 'rd3-piechart-value');
+    expect(labels.length).to.equal(0);    
+  });
+
+  it('doesnt show outer labels if not specified', function() {
+    var piechart = TestUtils.renderIntoDocument(
+      <PieChart 
+        data={data} width={400} height={200} 
+        showOuterLabels={false}
+      />
+    );
+    
+    var labels = TestUtils.scryRenderedDOMComponentsWithClass(piechart, 'rd3-piechart-label');
+    expect(labels.length).to.equal(0);    
+  });
 });


### PR DESCRIPTION
I want to have a custom legend for the PieChart, and don't want to show inner labels for a small chart (< 50px) where the text labels will not fit. The best option I saw was to allow disabling of the inner and outer labels via props to PieChart: `showInnerLabels` and `showOuterLabels`. Let me know if you had other thoughts on this or it doesn't look right.