### PR TITLE
Added stroke support to PieChart to enable lines between

### DIFF
--- a/docs/examples/main.js
+++ b/docs/examples/main.js
@@ -315,7 +315,7 @@ var Demos = React.createClass({
         </div>
         <div className="row">
           <div className="col-md-6">
-            <PieChart data={pieData} width={450} height={400} radius={110} innerRadius={20} title="Pie Chart" />
+            <PieChart data={pieData} width={450} height={400} radius={110} innerRadius={20} sectorBorderColor="white" title="Pie Chart" />
           </div>
           <div className="col-md-6">
             <pre ref='block'>
@@ -338,6 +338,7 @@ var Demos = React.createClass({
   height={400}
   radius={100}
   innerRadius={20}
+  sectorBorderColor="white"
   title="Pie Chart"
 />`
                 }

--- a/src/piechart/Arc.jsx
+++ b/src/piechart/Arc.jsx
@@ -17,6 +17,7 @@ module.exports = React.createClass({
     outerRadius: React.PropTypes.number,
     labelTextFill: React.PropTypes.string,
     valueTextFill: React.PropTypes.string,
+    sectorBorderColor: React.PropTypes.string,
     showInnerLabels: React.PropTypes.bool,
     showOuterLabels: React.PropTypes.bool
   },
@@ -26,7 +27,7 @@ module.exports = React.createClass({
       labelTextFill: 'black',
       valueTextFill: 'white',
       showInnerLabels: true,
-      showOuterLabels: true,
+      showOuterLabels: true
     };
   },
 
@@ -102,6 +103,7 @@ module.exports = React.createClass({
         <path
           d={arc()}
           fill={props.fill}
+          stroke={props.sectorBorderColor}
         />
         {outerLabels}
         {innerLabels}

--- a/src/piechart/DataSeries.jsx
+++ b/src/piechart/DataSeries.jsx
@@ -16,7 +16,8 @@ module.exports = React.createClass({
     radius: React.PropTypes.number,
     colors: React.PropTypes.func,
     showInnerLabels: React.PropTypes.bool,
-    showOuterLabels: React.PropTypes.bool
+    showOuterLabels: React.PropTypes.bool,
+    sectorBorderColor: React.PropTypes.string
   },
 
   getDefaultProps() {
@@ -54,6 +55,7 @@ module.exports = React.createClass({
           width={props.width}
           showInnerLabels={props.showInnerLabels}
           showOuterLabels={props.showOuterLabels}
+          sectorBorderColor={props.sectorBorderColor}
         />
       );
     });

--- a/src/piechart/PieChart.jsx
+++ b/src/piechart/PieChart.jsx
@@ -27,7 +27,8 @@ module.exports = React.createClass({
     colors: React.PropTypes.func,
     title: React.PropTypes.string,
     showInnerLabels: React.PropTypes.bool,
-    showOuterLabels: React.PropTypes.bool
+    showOuterLabels: React.PropTypes.bool,
+    sectorBorderColor: React.PropTypes.string
   },
 
   render: function() {
@@ -58,6 +59,7 @@ module.exports = React.createClass({
             innerRadius={props.innerRadius}
             showInnerLabels={props.showInnerLabels}
             showOuterLabels={props.showOuterLabels}
+            sectorBorderColor={props.sectorBorderColor}
           />
         </g>
       </Chart>


### PR DESCRIPTION
Passing in a `stroke` prop that is a string color (e.g. "white") to PieChart will render a white border around each segment, producing a chart like:
![screen shot 2015-04-21 at 4 20 24 pm](https://cloud.githubusercontent.com/assets/327903/7264627/5620524e-e842-11e4-81ca-3d848bf64914.png)
