### PR TITLE
Add interpolation to area chart

### DIFF
--- a/src/areachart/AreaChart.jsx
+++ b/src/areachart/AreaChart.jsx
@@ -18,13 +18,17 @@ module.exports = React.createClass({
   displayName: 'AreaChart',
 
   propTypes: {
-    margins: React.PropTypes.object
+    margins: React.PropTypes.object,
+    interpolate: React.PropTypes.bool,
+    interpolationType: React.PropTypes.string
  },
 
   getDefaultProps() {
     return {
       margins: {top: 10, right: 20, bottom: 40, left: 45},
       yAxisTickCount: 4,
+      interpolate: false,
+      interpolationType: null,
       className: 'rd3-areachart'
     };
   },
@@ -34,6 +38,8 @@ module.exports = React.createClass({
     var props = this.props;
 
     var data = props.data;
+
+    var interpolationType = props.interpolationType || (props.interpolate ? 'cardinal' : 'linear');
 
     // Calculate inner chart dimensions
     var innerWidth, innerHeight;
@@ -101,6 +107,7 @@ module.exports = React.createClass({
             data={d.values}
             xAccessor={props.xAccessor}
             yAccessor={props.yAccessor}
+            interpolationType={interpolationType}
           />
         );
       });

--- a/src/areachart/DataSeries.jsx
+++ b/src/areachart/DataSeries.jsx
@@ -7,6 +7,16 @@ var Area = require('./Area');
 module.exports = React.createClass({
 
   displayName: 'DataSeries',
+
+  propTypes: {
+    interpolationType: React.PropTypes.string
+  },
+
+  getDefaultProps() {
+    return {
+      interpolationType: 'linear'
+    };
+  },
   
   render() {
 
@@ -15,7 +25,8 @@ module.exports = React.createClass({
     var area = d3.svg.area()
       .x((d)=> { return props.xScale(props.xAccessor(d)); })
       .y0((d)=> { return props.yScale(d.y0); })
-      .y1((d)=> { return props.yScale(d.y0 + props.yAccessor(d)); });
+      .y1((d)=> { return props.yScale(d.y0 + props.yAccessor(d)); })
+      .interpolate(props.interpolationType);
 
     var path = area(props.data);
 

--- a/src/linechart/LineChart.jsx
+++ b/src/linechart/LineChart.jsx
@@ -25,7 +25,9 @@ module.exports = React.createClass({
     pointRadius: React.PropTypes.number,
     colors: React.PropTypes.func,
     displayDataPoints: React.PropTypes.bool,
-    hoverAnimation: React.PropTypes.bool
+    hoverAnimation: React.PropTypes.bool,
+    interpolate: React.PropTypes.bool,
+    interpolationType: React.PropTypes.string
   },
 
   getDefaultProps() {


### PR DESCRIPTION
I've implemented the the same interface to control interpolation as currently implemented in `LineChart` (using the `interpolate` and `interpolationType` props).

I also added some missing propTypes to `LineChart`.