### PR TITLE
Optional chart titles

### DIFF
--- a/src/common/charts/BasicChart.jsx
+++ b/src/common/charts/BasicChart.jsx
@@ -6,16 +6,43 @@ module.exports = React.createClass({
 
   displayName: 'BasicChart',
 
-  render: function() {
-    return (
-      <div>
+  propTypes: {
+    title: React.PropTypes.node,
+    viewBox: React.PropTypes.string,
+    width: React.PropTypes.number,
+    height: React.PropTypes.number,
+    children: React.PropTypes.node,
+  },
+
+  _renderTitle() {
+    if (this.props.title != null) {
+      return (
         <h4>{this.props.title}</h4>
-        <svg
-          viewBox={this.props.viewBox}
-          width={this.props.width}
-          height={this.props.height}
-        >{this.props.children}</svg>
-      </div>
+      );
+    }
+  },
+
+  _renderChart: function() {
+    return (
+      <svg
+        viewBox={this.props.viewBox}
+        width={this.props.width}
+        height={this.props.height}
+      >{this.props.children}</svg>
     );
+  },
+
+  render: function() {
+    if (this.props.title != null) {
+      return (
+        <div>
+          {this._renderTitle()}
+          {this._renderChart()}
+        </div>
+      );
+    }
+    else {
+      return this._renderChart();
+    }
   }
 });

--- a/src/common/charts/LegendChart.jsx
+++ b/src/common/charts/LegendChart.jsx
@@ -8,6 +8,11 @@ module.exports = React.createClass({
   displayName: 'LegendChart',
 
   propTypes: {
+    title: React.PropTypes.node,
+    viewBox: React.PropTypes.string,
+    width: React.PropTypes.number,
+    height: React.PropTypes.number,
+    children: React.PropTypes.node,
     legend: React.PropTypes.bool,
     legendPosition: React.PropTypes.string,
     sideOffset: React.PropTypes.number,
@@ -43,10 +48,19 @@ module.exports = React.createClass({
     }
   },
 
+  _renderTitle() {
+    if (this.props.title != null) {
+      return (
+        <h4>{this.props.title}</h4>
+      );
+      return null;
+    }
+  },
+
   render() {
     return (
       <div style={{'width': this.props.width, 'height': this.props.height}} >
-        <h4>{this.props.title}</h4>
+        {this._renderTitle()}
         {this._renderLegend()}
         <svg viewBox={this.props.viewBox} width={this.props.width - this.props.sideOffset} height={this.props.height}>{this.props.children}</svg>
       </div>

--- a/tests/basicchart-tests.js
+++ b/tests/basicchart-tests.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var expect = require('chai').expect;
+
+describe('BasicChart', function() {
+  it('renders and tests BasicChart component', function() {
+    var React = require('react/addons');
+    var BasicChart = require('../src/common/charts/BasicChart');
+    var generate = require('./utils/datagen').generateArrayOfPoints;
+    var TestUtils = React.addons.TestUtils;
+
+    var chart = TestUtils.renderIntoDocument(
+      <BasicChart /> 
+    );
+
+    var chartWithTitle = TestUtils.renderIntoDocument(
+      <BasicChart title="foo" /> 
+    );
+
+    // Verify there is no heading element
+    var noTitleHeadings = TestUtils.scryRenderedDOMComponentsWithTag(
+      chart, 'h4');
+    expect(noTitleHeadings).to.have.length(0);
+
+    // Verify there is a heading element
+    var titleHeadings = TestUtils.scryRenderedDOMComponentsWithTag(
+      chartWithTitle, 'h4');
+    expect(titleHeadings).to.have.length(1);
+  });
+});
+

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,3 +1,5 @@
+require('./legendchart-tests');
+require('./basicchart-tests');
 require('./barchart-tests');
 require('./linechart-tests');
 require('./areachart-tests');

--- a/tests/legendchart-tests.js
+++ b/tests/legendchart-tests.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var expect = require('chai').expect;
+
+describe('LegendChart', function() {
+  it('renders and tests LegendChart component', function() {
+    var React = require('react/addons');
+    var LegendChart = require('../src/common/charts/LegendChart');
+    var generate = require('./utils/datagen').generateArrayOfPoints;
+    var TestUtils = React.addons.TestUtils;
+
+    var legend = TestUtils.renderIntoDocument(
+      <LegendChart /> 
+    );
+
+    var legendWithTitle = TestUtils.renderIntoDocument(
+      <LegendChart title="foo" /> 
+    );
+
+    // Verify there is no heading element
+    var noTitleHeadings = TestUtils.scryRenderedDOMComponentsWithTag(
+      legend, 'h4');
+    expect(noTitleHeadings).to.have.length(0);
+
+    // Verify there is a heading element
+    var titleHeadings = TestUtils.scryRenderedDOMComponentsWithTag(
+      legendWithTitle, 'h4');
+    expect(titleHeadings).to.have.length(1);
+  });
+});


### PR DESCRIPTION
I need charts to render without a title and currently even if you don't pass in a `title` prop, an `h4` element is rendered. This changes `BasicChart` and `LegendChart` to not render any unnecessary elements.