### PR TITLE
Bug fix in linechart/DataSeries

### DIFF
--- a/src/linechart/DataSeries.jsx
+++ b/src/linechart/DataSeries.jsx
@@ -12,6 +12,7 @@ module.exports = React.createClass({
 
   propTypes: {
     data: React.PropTypes.array,
+    seriesName: React.PropTypes.string,
     interpolationType: React.PropTypes.string,
     fill: React.PropTypes.string,
     xAccessor: React.PropTypes.func,
@@ -22,6 +23,7 @@ module.exports = React.createClass({
   getDefaultProps() {
     return {
       data: [],
+      seriesName: "",
       interpolationType: 'linear',
       fill: '#fff',
       xAccessor: (d) => d.x,
@@ -38,6 +40,12 @@ module.exports = React.createClass({
 
     var props = this.props;
 
+    // Check to see if there is any data to draw lines/circles with
+    // Return null if there is nothing to draw (null will become <noscript>)
+    if (props.data.length === 0) {
+      return null;
+    }
+
     var xAccessor = props.xAccessor,
         yAccessor = props.yAccessor;
 
@@ -52,16 +60,16 @@ module.exports = React.createClass({
     // Check whether or not an arbitrary data element
     // is a date object (at index 0 here)
     // If it's a date, then we set the x scale a bit differently
+    // NOTE: a sparse array could still break this, even with the length check above
     if (this._isDate(props.data[0], xAccessor)) {
-        interpolatePath.x(function(d) {
-          return props.xScale(props.xAccessor(d).getTime());
-        });
+      interpolatePath.x(function(d) {
+        return props.xScale(props.xAccessor(d).getTime());
+      });
     } else {
-        interpolatePath.x(function(d) {
-          return props.xScale(props.xAccessor(d));
-        });
+      interpolatePath.x(function(d) {
+        return props.xScale(props.xAccessor(d));
+      });
     }
-
 
     // Create an immstruct reference for the series name
     // and set it to 'inactive'
@@ -91,7 +99,7 @@ module.exports = React.createClass({
           cy = props.yScale(yAccessor(point));
         }
 
-        var id= props.seriesName + '-' + idx;
+        var id = props.seriesName + '-' + idx;
 
         // Create an immstruct reference for the circle id
         // and set it to 'inactive'

--- a/src/linechart/Line.jsx
+++ b/src/linechart/Line.jsx
@@ -8,7 +8,6 @@ module.exports = React.createClass({
   displayName: 'Line',
 
   propTypes: {
-    data: React.PropTypes.object,
     strokeWidth: React.PropTypes.number,
     path: React.PropTypes.string,
     fill: React.PropTypes.string,
@@ -51,13 +50,13 @@ module.exports = React.createClass({
   },
 
   _animateLine(id) {
-    this.setState({ 
+    this.setState({
       lineStrokeWidth: this.state.lineStrokeWidth * 1.8
     });
   },
 
   _restoreLine(id) {
-    this.setState({ 
+    this.setState({
       lineStrokeWidth: this.props.strokeWidth
     });
   },


### PR DESCRIPTION
Fixed a bug in the linechart/DataSeries component where the render method was polling the first value of the data array to check for the x-axis data type, without first checking to see if the element of the data array was defined. A check has been placed into DataSeries's render() to check the length of the array first, returning null if it is empty. Note that this check does not cover sparse arrays, which will still potentially cause the render to fail.

I also added a PropType for seriesName in DataSeries and added a default value for it since it is required by portions of the code, such as creating an id. I also removed the PropType for data from linechart/Line since the data prop is not used by Line, and, it was the wrong type anyways.