### PR TITLE
Scatterchart series color

### DIFF
--- a/src/scatterchart/DataSeries.jsx
+++ b/src/scatterchart/DataSeries.jsx
@@ -30,7 +30,7 @@ module.exports = React.createClass({
     var yScale = props.yScale;
     var xAccessor = props.xAccessor,
         yAccessor = props.yAccessor,
-        cx, cy;
+        cx, cy, circleFill;
 
     var voronoi = d3.geom.voronoi()
       .x(function(d){ return xScale(d.coord.x); })
@@ -50,9 +50,11 @@ module.exports = React.createClass({
         cy = props.yScale(yAccessor(point));
       }
 
+      circleFill = props.colors(vnode.point.seriesName);
+      
       return (
           <VoronoiCircleContainer 
-              key={idx} id={vnode.point.id} vnode={vnode} 
+              key={idx} circleFill={circleFill} vnode={vnode}
               cx={cx} cy={cy} circleRadius={props.circleRadius}
           />
       )

--- a/src/scatterchart/ScatterChart.jsx
+++ b/src/scatterchart/ScatterChart.jsx
@@ -2,13 +2,10 @@
 
 var React = require('react');
 var d3 = require('d3');
-var common = require('../common');
-var Chart = common.Chart;
-var XAxis = common.XAxis;
-var YAxis = common.YAxis;
+var { Chart, XAxis, YAxis } = require('../common');
 var DataSeries = require('./DataSeries')
 var utils = require('../utils');
-var CartesianChartPropsMixin = require('../mixins').CartesianChartPropsMixin;
+var { CartesianChartPropsMixin } = require('../mixins');
 
 module.exports = React.createClass({
 
@@ -73,9 +70,7 @@ module.exports = React.createClass({
     var allValues = flattenedData.allValues,
         xValues = flattenedData.xValues,
         yValues = flattenedData.yValues;
-
     var scales = this._calculateScales(innerWidth, innerHeight, xValues, yValues);
-
     var trans = "translate(" + (props.yAxisOffset < 0 ? props.margins.left + Math.abs(props.yAxisOffset) : props.margins.left) + "," + props.margins.top + ")";
 
     return (
@@ -84,7 +79,6 @@ module.exports = React.createClass({
         legend={props.legend}
         data={props.data}
         margins={props.margins}
-        colors={props.colors}
         width={props.width}
         height={props.height}
         title={props.title}>
@@ -97,6 +91,7 @@ module.exports = React.createClass({
             hoverAnimation={props.hoverAnimation}
             circleRadius={props.circleRadius}
             data={allValues}
+            colors={props.colors}
             width={innerWidth}
             height={innerHeight}
           />

--- a/src/scatterchart/VoronoiCircleContainer.jsx
+++ b/src/scatterchart/VoronoiCircleContainer.jsx
@@ -12,7 +12,7 @@ module.exports = React.createClass({
   getDefaultProps() {
     return { 
       circleRadius: 3,
-      initialFill: '#1f77b4',
+      circleFill: '#1f77b4',
       hoverAnimation: true
     }
   },
@@ -20,7 +20,7 @@ module.exports = React.createClass({
   getInitialState() {
     return { 
       circleRadius: this.props.circleRadius,
-      circleFill: this.props.initialFill
+      circleFill: this.props.circleFill
     }
   },
 
@@ -56,14 +56,14 @@ module.exports = React.createClass({
   _animateCircle() {
     this.setState({ 
       circleRadius: this.props.circleRadius * ( 5 / 4 ),
-      circleFill: shade(this.props.initialFill, 0.2)
+      circleFill: shade(this.props.circleFill, 0.2)
     });
   },
 
   _restoreCircle() {
     this.setState({ 
       circleRadius: this.props.circleRadius,
-      circleFill: this.props.initialFill
+      circleFill: this.props.circleFill
     });
   },
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -114,7 +114,8 @@ exports.flattenData = (data, xAccessor, yAccessor) => {
           x: x,
           y: yNode,
         },
-        id: `${ series.name }-${ idx }`
+        id: `${ series.name }-${ idx }`,
+        seriesName: series.name
       };
       allValues.push(pointItem);
     });

--- a/tests/scatterchart-tests.js
+++ b/tests/scatterchart-tests.js
@@ -1,18 +1,20 @@
 'use strict';
 
 var expect = require('chai').expect;
+var React = require('react/addons');
+var { ScatterChart } = require('../src/scatterchart');
+var { generateArrayOfPoints: generate } = require('./utils/datagen');
+
+var TestUtils = React.addons.TestUtils;
+var points = 5;
+var circleRadius = 5;
+var data, scatterchart;
 
 describe('ScatterChart', function() {
-  it('renders scatterchart', function() {
-    var React = require('react/addons');
-    var ScatterChart = require('../src/scatterchart').ScatterChart;
-    var generate = require('./utils/datagen').generateArrayOfPoints;
-    var TestUtils = React.addons.TestUtils;
-    var points = 5;
-    var circleRadius = 5;
 
+  before(function() {
     // Render a scatterchart 
-    var data = [
+    data = [
       {
         name: "series1",
         values: generate(points)
@@ -22,32 +24,66 @@ describe('ScatterChart', function() {
         values: generate(points)
       }
     ];
-
-    var scatterchart = TestUtils.renderIntoDocument(
+    scatterchart = TestUtils.renderIntoDocument(
       <ScatterChart data={data} width={400} height={200} circleRadius={circleRadius} />
     );
+
+  })
+
+  it('renders scatter chart', function() {
 
     var scatterchartGroup = TestUtils.findRenderedDOMComponentWithClass(
       scatterchart, 'rd3-scatterchart');
     expect(scatterchartGroup).to.exist;
     expect(scatterchartGroup.tagName).to.equal('G');
 
+  });
+
+  it('renders same amount of circles with data', function() {
+
     var circles = TestUtils.scryRenderedDOMComponentsWithClass(
       scatterchart, 'rd3-scatterchart-circle');
     expect(circles).to.have.length(Object.keys(data).length * points);
-
-    var circleOne = circles[0];
-    var circleOneColor = circleOne.props.fill;
-
-    expect(circleOne.props.r).to.equal(circleRadius);
-    TestUtils.Simulate.mouseOver(circleOne);
-    expect(circleOne.props.r).to.be.above(circleRadius);
-    expect(circleOne.props.fill).to.not.equal(circleOneColor);
-
-    // TestUtils.Simulate.mouseOut(circleOne) is not working here
-    // https://github.com/facebook/react/issues/1297
-    TestUtils.SimulateNative.mouseOut(circleOne);
-    expect(circleOne.props.r).to.equal(circleRadius);
-    expect(circleOne.props.fill).to.equal(circleOneColor);
+  
   });
+
+  it('circle color is different from other series', function() {
+
+    var circles = TestUtils.scryRenderedDOMComponentsWithClass(
+      scatterchart, 'rd3-scatterchart-circle');
+
+    // uses this naive approach because TestUtils does not have
+    // something like findRenderedDOMComponentWithProps
+    var firstCircle = circles[0],
+        secondCircle = circles[1],
+        lastCircle = circles[circles.length - 1];
+    
+    // we know that first and second circle are in same series
+    expect(firstCircle.props.fill).to.equal(secondCircle.props.fill);
+
+    // we know that first and last circle are not in same series
+    expect(firstCircle.props.fill).to.not.equal(lastCircle.props.fill);
+
+  });
+
+  it('circle is animated when hovered', function() {
+
+      var circle = TestUtils.scryRenderedDOMComponentsWithClass(
+        scatterchart, 'rd3-scatterchart-circle')[0];
+
+      // circle color before hovered
+      var circleColor = circle.props.fill;
+
+      expect(circle.props.r).to.equal(circleRadius);
+      TestUtils.Simulate.mouseOver(circle);
+      expect(circle.props.r).to.be.above(circleRadius);
+      expect(circle.props.fill).to.not.equal(circleColor);
+
+      // TestUtils.Simulate.mouseOut(circle) is not working here
+      // https://github.com/facebook/react/issues/1297
+      TestUtils.SimulateNative.mouseOut(circle);
+      expect(circle.props.r).to.equal(circleRadius);
+      expect(circle.props.fill).to.equal(circleColor);    
+  });
+
 });


### PR DESCRIPTION
This was my mistake. In scatter chart, all circles are rendered with same color. Color should differ if they are not from the same series. 

Added another property `seriesName` to the objects of allValues in `utils/index.js`. Added a test for this to prevent future mistake.

Also I realised that in those graphs that we are using d3 color palettes, users don't really have a option to color their graph. They can only opt for another 3 color palettes that d3 provided. Might open another issue regarding this if you want a further discussion.