### PR TITLE
Fixes a bug that causes linechart/Line and linechart/Circle to not update their color properly

### DIFF
--- a/src/linechart/Circle.jsx
+++ b/src/linechart/Circle.jsx
@@ -29,6 +29,13 @@ module.exports = React.createClass({
     };
   },
 
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      circleRadius: nextProps.r,
+      circleColor:  nextProps.fill
+    });
+  },
+
   componentDidMount() {
     var props = this.props;
     // The circle reference is observed when both it is set to
@@ -63,15 +70,15 @@ module.exports = React.createClass({
       />
     );
   },
-  
+
   _animateCircle(id) {
-    this.setState({ 
+    this.setState({
       circleRadius: this.state.circleRadius * ( 5 / 4 )
     });
   },
 
   _restoreCircle(id) {
-    this.setState({ 
+    this.setState({
       circleRadius: this.props.r
     });
   }

--- a/src/linechart/Line.jsx
+++ b/src/linechart/Line.jsx
@@ -26,9 +26,16 @@ module.exports = React.createClass({
   getInitialState() {
     // state for animation usage
     return {
-      lineStrokeWidth: this.props.strokeWidth,
-      lineStroke: this.props.stroke
+      lineStroke:      this.props.stroke,
+      lineStrokeWidth: this.props.strokeWidth
     };
+  },
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      lineStroke:      nextProps.stroke,
+      lineStrokeWidth: nextProps.strokeWidth
+    });
   },
 
   componentDidMount() {


### PR DESCRIPTION
Fixes a bug that caused the `linechart/Line` and `linechart/Circle` to not update their colors when their `props.fill` property changed if the component was already mounted. This is because `getInitialState` is only called the fist time the component is mounted, not every time it is rendered. Especially since we use non-random keys, most of the time the components are re-used instead of destroyed (unmounted) and recreated (mounted).