### PR TITLE
Added a ViewBoxMixin that lets charts configure their viewbox

### DIFF
--- a/docs/examples/main.js
+++ b/docs/examples/main.js
@@ -96,8 +96,14 @@ var Demos = React.createClass({
             <LineChart
               legend={true}
               data={lineData}
-              width={500}
-              height={300}
+              width='100%'
+              height={400}
+              viewBoxObject={{
+                x: 0,
+                y: 0,
+                width: 500,
+                height: 400
+              }}
               title="Line Chart"
               yAxisLabel="Altitude"
               xAxisLabel="Elapsed Time (sec)"
@@ -127,8 +133,14 @@ var Demos = React.createClass({
 `<LineChart
   legend={true}
   data={lineData}
-  width={500}
-  height={300}
+  width='100%'
+  height={400}
+  viewBoxObject={
+    x: 0,
+    y: 0,
+    width: 500,
+    height: 400
+  }
   title="Line Chart"
   yAxisLabel="Altitude"
   xAxisLabel="Elapsed Time (sec)"
@@ -185,7 +197,13 @@ var Demos = React.createClass({
           <div className="col-md-6">
             <AreaChart
               data={this.state.areaData}
-              width={500}
+              width="100%"
+              viewBoxObject={{
+                x: 0,
+                y: 0,
+                height: 400,
+                width: 500
+              }}
               height={400}
               title="Area Chart"
               xAxisTickInterval={{unit: 'year', interval: 2}}
@@ -221,8 +239,14 @@ var Demos = React.createClass({
                 {
 `<AreaChart
   data={areaData}
-  width={400}
+  width="100%"
   height={300}
+  viewBoxObject={
+    x: 0,
+    y: 0,
+    heigth: 400,
+    width: 500
+  }
   xAxisTickInterval={{unit: 'year', interval: 2}}
   title="Area Chart"
 />`

--- a/src/areachart/AreaChart.jsx
+++ b/src/areachart/AreaChart.jsx
@@ -7,13 +7,11 @@ var common = require('../common');
 var Chart = common.Chart;
 var XAxis = common.XAxis;
 var YAxis = common.YAxis;
-var mixins = require('../mixins');
-var CartesianChartPropsMixin = mixins.CartesianChartPropsMixin;
-
+var { CartesianChartPropsMixin, ViewBoxMixin } = require('../mixins');
 
 module.exports = React.createClass({
 
-  mixins: [ CartesianChartPropsMixin ],
+  mixins: [ CartesianChartPropsMixin, ViewBoxMixin ],
 
   displayName: 'AreaChart',
 
@@ -43,12 +41,8 @@ module.exports = React.createClass({
 
     // Calculate inner chart dimensions
     var innerWidth, innerHeight;
-    innerWidth = props.width - props.margins.left - props.margins.right;
-    innerHeight = props.height - props.margins.top - props.margins.bottom;
-
-    if (props.legend) {
-      innerWidth = innerWidth - props.legendOffset;
-    }
+    innerWidth = this.getOuterDimensions().width - props.margins.left - props.margins.right;
+    innerHeight = this.getOuterDimensions().height - props.margins.top - props.margins.bottom;
 
     if (!Array.isArray(data)) {
       data = [data];
@@ -114,7 +108,7 @@ module.exports = React.createClass({
 
     return (
       <Chart
-        viewBox={props.viewBox}
+        viewBox={this.getViewBox()}
         legend={props.legend}
         data={data}
         margins={props.margins}

--- a/src/candlestick/CandlestickChart.jsx
+++ b/src/candlestick/CandlestickChart.jsx
@@ -66,10 +66,6 @@ module.exports = React.createClass({
     innerWidth = props.width - props.margins.left - props.margins.right;
     innerHeight = props.height - props.margins.top - props.margins.bottom;
 
-    if (props.legend) {
-      innerWidth = innerWidth - props.legendOffset;
-    }
-
     if (!Array.isArray(props.data)) {
       props.data = [props.data];
     }

--- a/src/common/Legend.jsx
+++ b/src/common/Legend.jsx
@@ -59,18 +59,15 @@ module.exports = React.createClass({
 
     });
 
-    // In preparation for legend positioning
-    var legendFloat = 'right';
-
     var topMargin = props.margins.top;
 
     var legendBlockStyle = {
       'wordWrap': 'break-word',
-      'width': props.sideOffset,
+      'width': props.width,
       'paddingLeft': '0',
       'marginBottom': '0',
       'marginTop': topMargin,
-      'float': legendFloat
+      'list-style-position': 'inside'
     };
 
     return <ul style={legendBlockStyle}>{legendItems}</ul>;

--- a/src/common/charts/BasicChart.jsx
+++ b/src/common/charts/BasicChart.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react');
+var mixins = require('../../mixins');
 
 module.exports = React.createClass({
 
@@ -8,7 +9,6 @@ module.exports = React.createClass({
 
   propTypes: {
     title:    React.PropTypes.node,
-    viewBox:  React.PropTypes.string,
     width:    React.PropTypes.number,
     height:   React.PropTypes.number,
     children: React.PropTypes.node,

--- a/src/common/charts/Chart.jsx
+++ b/src/common/charts/Chart.jsx
@@ -10,7 +10,6 @@ module.exports = React.createClass({
   
   propTypes: {
     legend: React.PropTypes.bool,
-    viewBox: React.PropTypes.string
   },
 
   getDefaultProps: function() {

--- a/src/common/charts/LegendChart.jsx
+++ b/src/common/charts/LegendChart.jsx
@@ -11,12 +11,12 @@ module.exports = React.createClass({
     colors:         React.PropTypes.func,
     colorAccessor:  React.PropTypes.func,
     title:          React.PropTypes.node,
-    viewBox:        React.PropTypes.string,
-    width:          React.PropTypes.number,
-    height:         React.PropTypes.number,
+    width:          React.PropTypes.node,
+    height:         React.PropTypes.node,
     children:       React.PropTypes.node,
     legend:         React.PropTypes.bool,
     legendPosition: React.PropTypes.string,
+    viewBox:        React.PropTypes.string,
     sideOffset:     React.PropTypes.number,
     margins:        React.PropTypes.object,
     data:           React.PropTypes.oneOfType([
@@ -47,9 +47,8 @@ module.exports = React.createClass({
           colors={props.colors}
           colorAccessor={props.colorAccessor}
           data={props.data}
-          width={props.width}
+          width={props.sideOffset}
           height={props.height}
-          sideOffset={props.sideOffset}
         />
       );
     }
@@ -69,8 +68,14 @@ module.exports = React.createClass({
     return (
       <div style={{'width': props.width, 'height': props.height}} >
         {this._renderTitle()}
-        {this._renderLegend()}
-        <svg viewBox={props.viewBox} width={props.width - props.sideOffset} height={props.height}>{props.children}</svg>
+        <div style={{ display: 'table', width: '100%', height: '100%' }}>
+          <div style={{ display: 'table-cell' }}>
+            <svg viewBox={props.viewBox} width="100%" height="100%">{props.children}</svg>
+          </div>
+          <div style={{ display: 'table-cell', width: props.sideOffset, 'vertical-align': 'top' }}>
+            {this._renderLegend()}
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/linechart/LineChart.jsx
+++ b/src/linechart/LineChart.jsx
@@ -10,13 +10,11 @@ var Voronoi = common.Voronoi;
 var utils = require('../utils');
 var immstruct = require('immstruct');
 var DataSeries = require('./DataSeries');
-var mixins = require('../mixins');
-var CartesianChartPropsMixin = mixins.CartesianChartPropsMixin;
-
+var { CartesianChartPropsMixin, ViewBoxMixin } = require('../mixins');
 
 module.exports = React.createClass({
 
-  mixins: [ CartesianChartPropsMixin ],
+  mixins: [ CartesianChartPropsMixin, ViewBoxMixin ],
 
   displayName: 'LineChart',
 
@@ -54,12 +52,8 @@ module.exports = React.createClass({
     // Calculate inner chart dimensions
     var innerWidth, innerHeight;
 
-    innerWidth = props.width - props.margins.left - props.margins.right;
-    innerHeight = props.height - props.margins.top - props.margins.bottom;
-
-    if (props.legend) {
-      innerWidth = innerWidth - props.legendOffset;
-    }
+    innerWidth = this.getOuterDimensions().width - props.margins.left - props.margins.right;
+    innerHeight = this.getOuterDimensions().height - props.margins.top - props.margins.bottom;
 
     if (!Array.isArray(data)) {
       data = [data];
@@ -98,7 +92,7 @@ module.exports = React.createClass({
 
     return (
       <Chart
-        viewBox={props.viewBox}
+        viewBox={this.getViewBox()}
         legend={props.legend}
         data={data}
         margins={props.margins}

--- a/src/mixins/CartesianChartPropsMixin.js
+++ b/src/mixins/CartesianChartPropsMixin.js
@@ -27,12 +27,15 @@ module.exports =  {
     xAxisFormatter:    React.PropTypes.func,
     legend:            React.PropTypes.bool,
     legendOffset:      React.PropTypes.number,
-    width:             React.PropTypes.number,
-    height:            React.PropTypes.number,
+    width:             React.PropTypes.oneOf([
+      React.PropTypes.number, React.PropTypes.string,
+    ]),
+    height:            React.PropTypes.oneOf([
+      React.PropTypes.number, React.PropTypes.string,
+    ]),
     xAccessor:         React.PropTypes.func,
     yAccessor:         React.PropTypes.func,
-    title:             React.PropTypes.string,
-    viewBox:           React.PropTypes.string
+    title:             React.PropTypes.string
   },
 
   getDefaultProps: function() {
@@ -56,5 +59,4 @@ module.exports =  {
       yAccessor:        (d) => d.y
     };
   }
-
 };

--- a/src/mixins/ViewBoxMixin.js
+++ b/src/mixins/ViewBoxMixin.js
@@ -1,0 +1,36 @@
+
+'use strict';
+
+var React = require('react');
+
+module.exports =  {
+
+  propTypes: {
+    viewBox:           React.PropTypes.string,
+    viewBoxObject:     React.PropTypes.object
+  },
+
+  getViewBox() {
+    if (this.props.viewBoxObject) {
+      var v = this.props.viewBoxObject;
+      return [v.x, v.y, v.width, v.height].join(' ');
+    } else if (this.props.viewBox) {
+      return this.props.viewBox;
+    } 
+  },
+
+  getOuterDimensions() {
+    if (this.props.viewBoxObject) {
+      return {
+        width: this.props.viewBoxObject.width,
+        height: this.props.viewBoxObject.height
+      };
+    } else {
+      return {
+        width: this.props.width,
+        height: this.props.height
+      };
+    }
+  }
+
+};

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -1,2 +1,3 @@
 
 exports.CartesianChartPropsMixin = require('./CartesianChartPropsMixin');
+exports.ViewBoxMixin = require('./ViewBoxMixin');

--- a/src/scatterchart/ScatterChart.jsx
+++ b/src/scatterchart/ScatterChart.jsx
@@ -5,11 +5,11 @@ var d3 = require('d3');
 var { Chart, XAxis, YAxis } = require('../common');
 var DataSeries = require('./DataSeries')
 var utils = require('../utils');
-var { CartesianChartPropsMixin } = require('../mixins');
+var { CartesianChartPropsMixin, ViewBoxMixin } = require('../mixins');
 
 module.exports = React.createClass({
 
-  mixins: [ CartesianChartPropsMixin ],
+  mixins: [ CartesianChartPropsMixin, ViewBoxMixin ],
 
   displayName: 'ScatterChart',
 
@@ -40,12 +40,8 @@ module.exports = React.createClass({
     // Calculate inner chart dimensions
     var innerWidth, innerHeight;
 
-    innerWidth = props.width - props.margins.left - props.margins.right;
-    innerHeight = props.height - props.margins.top - props.margins.bottom;
-
-    if (props.legend) {
-      innerWidth = innerWidth - props.legendOffset;
-    }
+    innerWidth = this.getOuterDimensions().width - props.margins.left - props.margins.right;
+    innerHeight = this.getOuterDimensions().height - props.margins.top - props.margins.bottom;
 
     if (!Array.isArray(props.data)) {
       props.data = [props.data];
@@ -62,7 +58,7 @@ module.exports = React.createClass({
 
     return (
       <Chart
-        viewBox={props.viewBox}
+        viewBox={this.getViewBox()}
         legend={props.legend}
         data={props.data}
         margins={props.margins}


### PR DESCRIPTION
Following discussion on this issue here: https://github.com/esbullington/react-d3/issues/204 I implemented a proposed solution and show it working for the AreaChart. The remaining charts have yet to be updated. By using the `ViewBoxMixin` charts can accept a `viewBoxObject` prop that will let charts access outer chart dimensions as pixel values, and generate a string viewBox value that can be set on the svg element. See the AreaChart for an example. Comments/thoughts appreciated - this doesn't need to be merged in but is rather another starting point for the discussions that seemed to have stagnated a bit.