### PR TITLE
Added props.colors and props.colorAccessor support to BarChart

### DIFF
--- a/src/barchart/BarChart.jsx
+++ b/src/barchart/BarChart.jsx
@@ -57,7 +57,17 @@ module.exports = React.createClass({
     var trans = `translate(${ margins.left },${ margins.top })`;
 
     return (
-      <Chart width={props.width} height={props.height} title={props.title}>
+      <Chart
+        viewBox={props.viewBox}
+        legend={props.legend}
+        data={data}
+        margins={props.margins}
+        colors={props.colors}
+        colorAccessor={props.colorAccessor}
+        width={props.width}
+        height={props.height}
+        title={props.title}
+      >
         <g transform={trans} className='rd3-barchart'>
           <DataSeries
             values={values}

--- a/src/barchart/BarChart.jsx
+++ b/src/barchart/BarChart.jsx
@@ -60,7 +60,7 @@ module.exports = React.createClass({
       <Chart
         viewBox={props.viewBox}
         legend={props.legend}
-        data={data}
+        data={props.data}
         margins={props.margins}
         colors={props.colors}
         colorAccessor={props.colorAccessor}

--- a/src/barchart/BarChart.jsx
+++ b/src/barchart/BarChart.jsx
@@ -14,13 +14,12 @@ module.exports = React.createClass({
   displayName: 'BarChart',
 
   propTypes: {
-    data: React.PropTypes.array,
+    data:           React.PropTypes.array,
     yAxisTickCount: React.PropTypes.number,
-    width: React.PropTypes.number,
-    margins: React.PropTypes.object,
-    height: React.PropTypes.number,
-    fill: React.PropTypes.string,
-    title: React.PropTypes.string,
+    width:          React.PropTypes.number,
+    margins:        React.PropTypes.object,
+    height:         React.PropTypes.number,
+    title:          React.PropTypes.string,
     hoverAnimation: React.PropTypes.bool
   },
 
@@ -28,7 +27,6 @@ module.exports = React.createClass({
     return {
       yAxisTickCount: 4,
       margins: {top: 10, right: 20, bottom: 40, left: 45},
-      fill: "#3182bd",
       hoverAnimation: true
     };
   },
@@ -57,7 +55,7 @@ module.exports = React.createClass({
         .rangeRoundBands([0, props.width - sideMargins], 0.1);
 
     var trans = `translate(${ margins.left },${ margins.top })`;
-    
+
     return (
       <Chart width={props.width} height={props.height} title={props.title}>
         <g transform={trans} className='rd3-barchart'>
@@ -70,7 +68,8 @@ module.exports = React.createClass({
             data={props.data}
             width={props.width - sideMargins}
             height={props.height - topBottomMargins}
-            fill={props.fill}
+            colors={props.colors}
+            colorAccessor={props.colorAccessor}
             hoverAnimation={props.hoverAnimation}
           />
           <YAxis

--- a/src/barchart/DataSeries.jsx
+++ b/src/barchart/DataSeries.jsx
@@ -9,20 +9,19 @@ module.exports = React.createClass({
   displayName: 'DataSeries',
 
   propTypes: {
-    values: React.PropTypes.array,
-    labels: React.PropTypes.array,
-    fill: React.PropTypes.string,
-    title: React.PropTypes.string,
-    padding: React.PropTypes.number,
-    width: React.PropTypes.number,
-    height: React.PropTypes.number,
-    offset: React.PropTypes.number
+    values:        React.PropTypes.array,
+    labels:        React.PropTypes.array,
+    colors:        React.PropTypes.func,
+    colorAccessor: React.PropTypes.func,
+    width:         React.PropTypes.number,
+    height:        React.PropTypes.number,
+    offset:        React.PropTypes.number
   },
 
   getDefaultProps() {
     return {
       padding: 0.1,
-      data: []
+      values: []
     };
   },
 
@@ -42,7 +41,7 @@ module.exports = React.createClass({
           x={xScale(idx)}
           y={props.yScale(Math.max(0, point))}
           availableHeight={props.height}
-          fill={props.fill}
+          fill={props.colors(props.colorAccessor(point, idx))}
           key={idx}
           hoverAnimation={props.hoverAnimation}
         />


### PR DESCRIPTION
Modified `barchart/BarChart` and `barchart/Dataseries` to support the `props.colors` and `props.colorAccessor` functions.

Also passed missing properties into the containing `Chart`.

Note: this is not a breaking change. Users who currently pass the `fill` property to `barchart/BarChart` can still do so, though it will be ignored.