### PR TITLE
Changes and additions to Chart components

### DIFF
--- a/src/common/Legend.jsx
+++ b/src/common/Legend.jsx
@@ -8,19 +8,23 @@ module.exports = React.createClass({
   displayName: 'Legend',
 
   propTypes: {
-    width:         React.PropTypes.number,
-    height:        React.PropTypes.number,
+    className:     React.PropTypes.string,
+    colors:        React.PropTypes.func,
+    colorAccessor: React.PropTypes.func,
+    data:          React.PropTypes.array.isRequired,
+    itemClassName: React.PropTypes.string,
     margins:       React.PropTypes.object,
     text:          React.PropTypes.string,
-    colors:        React.PropTypes.func,
-    colorAccessor: React.PropTypes.func
+    width:         React.PropTypes.number.isRequired
   },
 
   getDefaultProps: function() {
     return {
-      text:          "#000",
+      className:    'rd3-legend',
       colors:        d3.scale.category20c(),
       colorAccessor: (d, idx) => idx,
+      itemClassName: 'rd3-legend-item',
+      text:          '#000'
     };
   },
 
@@ -46,8 +50,9 @@ module.exports = React.createClass({
 
       legendItems.push(
         <li
-          style={itemStyle}
           key={idx}
+          className={props.itemClassName}
+          style={itemStyle}
         >
           <span
             style={textStyle}
@@ -70,7 +75,14 @@ module.exports = React.createClass({
       'listStylePosition': 'inside'
     };
 
-    return <ul style={legendBlockStyle}>{legendItems}</ul>;
+    return (
+      <ul
+        className={props.className}
+        style={legendBlockStyle}
+      >
+        {legendItems}
+      </ul>
+    );
   }
 
 });

--- a/src/common/axes/Label.jsx
+++ b/src/common/axes/Label.jsx
@@ -7,46 +7,76 @@ module.exports = React.createClass({
 
   displayName: 'Label',
 
+  propTypes: {
+    height:              React.PropTypes.number,
+    horizontalTransform: React.PropTypes.string,
+    label:               React.PropTypes.string.isRequired,
+    width:               React.PropTypes.number,
+    strokeWidth:         React.PropTypes.number,
+    textAnchor:          React.PropTypes.string,
+    verticalTransform:   React.PropTypes.string
+  },
+
+  getDefaultProps() {
+    return {
+      horizontalTransform: 'rotate(270)',
+      strokeWidth:         0.01,
+      textAnchor:          'middle',
+      verticalTransform:   'rotate(0)'
+    };
+  },
+
   render() {
+
     var props = this.props;
-    var strokeWidth = '0.01';
+
     if (props.label) {
       switch (props.orient) {
         case 'top':
           return (
             <text
-              strokeWidth={strokeWidth}
-              y={props.offset} x={props.width/2}
-              textAnchor='middle' >
+              strokeWidth={props.strokeWidth.toString()}
+              textAnchor={props.textAnchor}
+              transform={props.verticalTransform}
+              x={props.width / 2}
+              y={props.offset}
+            >
               {props.label}
             </text>
           );
         case 'bottom':
           return (
             <text
-              strokeWidth={strokeWidth}
-              y={props.offset} x={props.width/2}
-              textAnchor='middle' >
+              strokeWidth={props.strokeWidth.toString()}
+              textAnchor={props.textAnchor}
+              transform={props.verticalTransform}
+              x={props.width / 2}
+              y={props.offset}
+            >
               {props.label}
             </text>
           );
         case 'left':
           return (
             <text
-              strokeWidth={strokeWidth}
-              y={-props.offset} x={-props.height/2}
-              textAnchor='middle'
-              transform='rotate(270)'>
+              strokeWidth={props.strokeWidth.toString()}
+              textAnchor={props.textAnchor}
+              transform={props.horizontalTransform}
+              y={-props.offset}
+              x={-props.height / 2}
+            >
               {props.label}
             </text>
           );
         case 'right':
           return (
             <text
-              strokeWidth={strokeWidth}
-              y={props.offset} x={-props.height/2}
-              textAnchor='middle'
-              transform='rotate(270)'>
+              strokeWidth={props.strokeWidth.toString()}
+              textAnchor={props.textAnchor}
+              transform={props.horizontalTransform}
+              y={props.offset}
+              x={-props.height / 2}
+            >
               {props.label}
             </text>
           );
@@ -56,5 +86,3 @@ module.exports = React.createClass({
   }
 
 });
-
-

--- a/src/common/axes/XAxis.jsx
+++ b/src/common/axes/XAxis.jsx
@@ -41,7 +41,7 @@ module.exports = React.createClass({
   render() {
     var props = this.props;
 
-    var t = 'translate(0,' + (props.xAxisOffset + props.height) + ')';
+    var t = `translate(0 ,${props.xAxisOffset + props.height})`;
 
     var tickArguments;
     if (typeof props.xAxisTickCount !== 'undefined') {

--- a/src/common/axes/XAxis.jsx
+++ b/src/common/axes/XAxis.jsx
@@ -9,44 +9,45 @@ var Label = require('./Label');
 module.exports = React.createClass({
 
   displayName: 'XAxis',
-  
+
   propTypes: {
-    xAxisClassName: React.PropTypes.string.isRequired,
+    fill:            React.PropTypes.string,
+    height:          React.PropTypes.number.isRequired,
+    stroke:          React.PropTypes.string,
+    strokeWidth:     React.PropTypes.string,
+    tickStroke:      React.PropTypes.string,
+    xAxisClassName:  React.PropTypes.string,
+    xAxisLabel:      React.PropTypes.string,
     xAxisTickValues: React.PropTypes.array,
-    xOrient: React.PropTypes.oneOf(['top', 'bottom']),
-    xScale: React.PropTypes.func.isRequired,
-    height: React.PropTypes.number.isRequired,
-    fill: React.PropTypes.string,
-    stroke: React.PropTypes.string,
-    tickStroke: React.PropTypes.string,
-    strokeWidth: React.PropTypes.string,
-    xAxisOffset: React.PropTypes.number
+    xAxisOffset:     React.PropTypes.number,
+    xScale:          React.PropTypes.func.isRequired,
+    xOrient:         React.PropTypes.oneOf(['top', 'bottom'])
   },
 
   getDefaultProps() {
     return {
-      xAxisClassName: 'x axis',
+      fill:            'none',
+      stroke:          'none',
+      strokeWidth:     'none',
+      tickStroke:      '#000',
+      xAxisClassName:  'rd3-x-axis',
+      xAxisLabel:      '',
       xAxisLabelOffset: 10,
-      xOrient: 'bottom',
-      fill: 'none',
-      stroke: 'none',
-      tickStroke: '#000',
-      strokeWidth: 'none',
-      xAxisOffset: 0,
-      label: ''
+      xAxisOffset:      0,
+      xOrient:         'bottom'
     };
   },
 
   render() {
     var props = this.props;
 
-    var t = `translate(0,${props.xAxisOffset + props.height})`;
+    var t = 'translate(0,' + (props.xAxisOffset + props.height) + ')';
 
     var tickArguments;
     if (typeof props.xAxisTickCount !== 'undefined') {
       tickArguments = [props.xAxisTickCount];
     }
-    
+
     if (typeof props.xAxisTickInterval !== 'undefined') {
       tickArguments = [d3.time[props.xAxisTickInterval.unit], props.xAxisTickInterval.interval];
     }

--- a/src/common/axes/YAxis.jsx
+++ b/src/common/axes/YAxis.jsx
@@ -43,9 +43,9 @@ module.exports = React.createClass({
 
     var t;
     if (props.yOrient === 'right') {
-       t = 'translate(' + (props.yAxisOffset + props.width) + ',0)';
+       t = `translate(${props.yAxisOffset + props.width}, 0)`;
     } else {
-       t = 'translate(' + props.yAxisOffset + ',0)';
+       t = `translate(${props.yAxisOffset}, 0)`;
     }
 
     var tickArguments;

--- a/src/common/axes/YAxis.jsx
+++ b/src/common/axes/YAxis.jsx
@@ -11,26 +11,29 @@ module.exports = React.createClass({
   displayName: 'YAxis',
 
   propTypes: {
-    yAxisClassName: React.PropTypes.string,
+    fill:            React.PropTypes.string,
+    stroke:          React.PropTypes.string,
+    strokeWidth:     React.PropTypes.string,
+    tickStroke:      React.PropTypes.string,
+    width:           React.PropTypes.number.isRequired,
+    yAxisClassName:  React.PropTypes.string,
+    yAxisLabel:      React.PropTypes.string,
+    yAxisOffset:     React.PropTypes.number,
     yAxisTickValues: React.PropTypes.array,
-    yOrient: React.PropTypes.oneOf(['left', 'right']),
-    yScale: React.PropTypes.func.isRequired,
-    fill: React.PropTypes.string,
-    stroke: React.PropTypes.string,
-    tickStroke: React.PropTypes.string,
-    strokeWidth: React.PropTypes.string,
-    yAxisOffset: React.PropTypes.number
+    yOrient:         React.PropTypes.oneOf(['left', 'right']),
+    yScale:          React.PropTypes.func.isRequired
   },
 
   getDefaultProps() {
     return {
-      yAxisClassName: 'y axis',
-      yOrient: 'left',
-      fill: 'none',
-      stroke: '#000',
-      tickStroke: '#000',
-      strokeWidth: '1',
-      yAxisOffset: 0
+      fill:           'none',
+      stroke:         '#000',
+      strokeWidth:    '1',
+      tickStroke:     '#000',
+      yAxisClassName: 'rd3-y-axis',
+      yAxisLabel:     '',
+      yAxisOffset:    0,
+      yOrient:        'left'
     };
   },
 
@@ -40,16 +43,16 @@ module.exports = React.createClass({
 
     var t;
     if (props.yOrient === 'right') {
-       t = `translate(${props.yAxisOffset + props.width},0)`;
+       t = 'translate(' + (props.yAxisOffset + props.width) + ',0)';
     } else {
-       t = `translate(${props.yAxisOffset},0)`;
+       t = 'translate(' + props.yAxisOffset + ',0)';
     }
 
     var tickArguments;
     if (props.yAxisTickCount) {
       tickArguments = [props.yAxisTickCount];
     }
-    
+
     if (props.yAxisTickInterval) {
       tickArguments = [d3.time[props.yAxisTickInterval.unit], props.yAxisTickInterval.interval];
     }
@@ -60,29 +63,28 @@ module.exports = React.createClass({
         transform={t}
       >
         <AxisTicks
-          tickValues={props.yAxisTickValues}
-          tickFormatting={props.tickFormatting}
+          innerTickSize={props.tickSize}
+          orient={props.yOrient}
           tickArguments={tickArguments}
+          tickFormatting={props.tickFormatting}
           tickStroke={props.tickStroke}
           tickTextStroke={props.tickTextStroke}
-          innerTickSize={props.tickSize}
+          tickValues={props.yAxisTickValues}
           scale={props.yScale}
-          orient={props.yOrient}
         />
         <AxisLine
-          scale={props.yScale}
-          stroke={props.stroke}
           orient={props.yOrient}
           outerTickSize={props.tickSize}
+          scale={props.yScale}
+          stroke={props.stroke}
           {...props}
         />
         <Label
+          height={props.height}
           label={props.yAxisLabel}
+          margins={props.margins}
           offset={props.yAxisLabelOffset}
           orient={props.yOrient}
-          margins={props.margins}
-          height={props.height}
-          width={props.width}
         />
       </g>
     );

--- a/src/common/charts/BasicChart.jsx
+++ b/src/common/charts/BasicChart.jsx
@@ -8,10 +8,21 @@ module.exports = React.createClass({
   displayName: 'BasicChart',
 
   propTypes: {
-    title:    React.PropTypes.node,
-    width:    React.PropTypes.node,
-    height:   React.PropTypes.node,
-    children: React.PropTypes.node,
+    children:       React.PropTypes.node,
+    className:      React.PropTypes.string,
+    height:         React.PropTypes.node,
+    svgClassName:   React.PropTypes.string,
+    title:          React.PropTypes.node,
+    titleClassName: React.PropTypes.string,
+    width:          React.PropTypes.node
+  },
+
+  getDefaultProps() {
+    return {
+      className:      'rd3-basic-chart',
+      svgClassName:   'rd3-chart',
+      titleClassName: 'rd3-chart-title'
+    };
   },
 
   _renderTitle() {
@@ -19,7 +30,11 @@ module.exports = React.createClass({
 
     if (props.title != null) {
       return (
-        <h4>{props.title}</h4>
+        <h4
+          className={props.titleClassName}
+        >
+          {props.title}
+        </h4>
       );
     } else {
       return null;
@@ -31,9 +46,10 @@ module.exports = React.createClass({
 
     return (
       <svg
+        className={props.svgClassName}
+        height={props.height}
         viewBox={props.viewBox}
         width={props.width}
-        height={props.height}
       >
         {props.children}
       </svg>
@@ -41,15 +57,15 @@ module.exports = React.createClass({
   },
 
   render: function() {
-    if (this.props.title != null) {
-      return (
-        <div>
-          {this._renderTitle()}
-          {this._renderChart()}
-        </div>
-      );
-    } else {
-      return this._renderChart();
-    }
+    var props = this.props;
+
+    return (
+      <div
+        className={props.className}
+      >
+        {this._renderTitle()}
+        {this._renderChart()}
+      </div>
+    );
   }
 });

--- a/src/common/charts/Chart.jsx
+++ b/src/common/charts/Chart.jsx
@@ -7,23 +7,40 @@ var BasicChart = require('./BasicChart');
 module.exports = React.createClass({
 
   displayName: 'Chart',
-  
+
   propTypes: {
-    legend: React.PropTypes.bool,
+    legend:         React.PropTypes.bool,
+    svgClassName:   React.PropTypes.string,
+    titleClassName: React.PropTypes.string
   },
 
   getDefaultProps: function() {
     return {
-      legend: false
+      legend:         false,
+      svgClassName:   'rd3-chart',
+      titleClassName: 'rd3-chart-title'
     };
   },
 
   render: function() {
-    if (this.props.legend) {
-      return <LegendChart {...this.props} />;
+    var props = this.props;
+
+    if (props.legend) {
+      return (
+        <LegendChart
+          svgClassName={props.svgClassName}
+          titleClassName={props.titleClassName}
+          {...this.props}
+        />
+      );
     }
-    return <BasicChart {...this.props} />;
+    return (
+      <BasicChart 
+        svgClassName={props.svgClassName}
+        titleClassName={props.titleClassName}
+        {...this.props}
+      />
+    );
   }
 
 });
-

--- a/src/common/charts/LegendChart.jsx
+++ b/src/common/charts/LegendChart.jsx
@@ -8,31 +8,34 @@ module.exports = React.createClass({
   displayName: 'LegendChart',
 
   propTypes: {
+    children:       React.PropTypes.node,
+    createClass:    React.PropTypes.string,
     colors:         React.PropTypes.func,
     colorAccessor:  React.PropTypes.func,
-    title:          React.PropTypes.node,
-    width:          React.PropTypes.node,
+    data:           React.PropTypes.array,
     height:         React.PropTypes.node,
-    children:       React.PropTypes.node,
     legend:         React.PropTypes.bool,
     legendPosition: React.PropTypes.string,
-    viewBox:        React.PropTypes.string,
-    sideOffset:     React.PropTypes.number,
     margins:        React.PropTypes.object,
-    data:           React.PropTypes.oneOfType([
-                      React.PropTypes.object,
-                      React.PropTypes.array
-                    ])
+    sideOffset:     React.PropTypes.number,
+    svgClassName:   React.PropTypes.string,
+    title:          React.PropTypes.node,
+    titleClassName: React.PropTypes.string,
+    viewBox:        React.PropTypes.string,
+    width:          React.PropTypes.node
   },
 
   getDefaultProps() {
     return {
-      data:           {},
+      className:      'rd3-legend-chart',
+      colors:         d3.scale.category20c(),
+      colorAccessor:  (d, idx) => idx,
+      data:           [],
       legend:         false,
       legendPosition: 'right',
       sideOffset:     90,
-      colors:         d3.scale.category20c(),
-      colorAccessor:  (d, idx) => idx
+      svgClassName:   'rd3-chart',
+      titleClassName: 'rd3-chart-title'
     };
   },
 
@@ -42,13 +45,12 @@ module.exports = React.createClass({
     if (props.legend) {
       return (
         <Legend
-          legendPosition={props.legendPosition}
-          margins={props.margins}
           colors={props.colors}
           colorAccessor={props.colorAccessor}
           data={props.data}
+          legendPosition={props.legendPosition}
+          margins={props.margins}
           width={props.sideOffset}
-          height={props.height}
         />
       );
     }
@@ -56,21 +58,46 @@ module.exports = React.createClass({
 
   _renderTitle() {
     var props = this.props;
+
     if (props.title != null) {
-      return <h4>{props.title}</h4>;
+      return (
+        <h4
+          className={props.titleClassName}
+        >
+          {props.title}
+        </h4>
+      );
     }
     return null;
+  },
+
+  _renderChart: function() {
+    var props = this.props;
+
+    return (
+      <svg
+        className={props.svgClassName}
+        height="100%"
+        viewBox={props.viewBox}
+        width="100%"
+      >
+        {props.children}
+      </svg>
+    );
   },
 
   render() {
     var props = this.props;
 
     return (
-      <div style={{'width': props.width, 'height': props.height}} >
+      <div
+        className={props.className}
+        style={{'width': props.width, 'height': props.height}}
+      >
         {this._renderTitle()}
         <div style={{ display: 'table', width: '100%', height: '100%' }}>
           <div style={{ display: 'table-cell' }}>
-            <svg viewBox={props.viewBox} width="100%" height="100%">{props.children}</svg>
+            {this._renderChart()}
           </div>
           <div style={{ display: 'table-cell', width: props.sideOffset, 'verticalAlign': 'top' }}>
             {this._renderLegend()}

--- a/src/mixins/CartesianChartPropsMixin.js
+++ b/src/mixins/CartesianChartPropsMixin.js
@@ -9,54 +9,56 @@ module.exports =  {
     axesColor:         React.PropTypes.string,
     colors:            React.PropTypes.func,
     colorAccessor:     React.PropTypes.func,
-    data:              React.PropTypes.oneOfType([
-                         React.PropTypes.array,
-                         React.PropTypes.object
-                       ]).isRequired,
-    xOrient:           React.PropTypes.oneOf(['top', 'bottom']),
-    yOrient:           React.PropTypes.oneOf(['left', 'right']),
-    yAxisTickCount:    React.PropTypes.number,
-    yAxisTickValues:   React.PropTypes.array,
-    yAxisLabel:        React.PropTypes.string,
-    yAxisLabelOffset:  React.PropTypes.number,
-    yAxisFormatter:    React.PropTypes.func,
-    xAxisTickValues:   React.PropTypes.array,
-    xAxisTickInterval: React.PropTypes.object,
-    xAxisLabel:        React.PropTypes.string,
-    xAxisLabelOffset:  React.PropTypes.number,
-    xAxisFormatter:    React.PropTypes.func,
+    data:              React.PropTypes.array.isRequired,
+    height:            React.PropTypes.number,
     legend:            React.PropTypes.bool,
     legendOffset:      React.PropTypes.number,
-    width:             React.PropTypes.oneOfType([
-      React.PropTypes.number, React.PropTypes.string,
-    ]),
-    height:            React.PropTypes.oneOfType([
-      React.PropTypes.number, React.PropTypes.string,
-    ]),
+    title:             React.PropTypes.string,
+    width:             React.PropTypes.number,
     xAccessor:         React.PropTypes.func,
+    xAxisFormatter:    React.PropTypes.func,
+    xAxisLabel:        React.PropTypes.string,
+    xAxisLabelOffset:  React.PropTypes.number,
+    xAxisTickCount:    React.PropTypes.number,
+    xAxisTickInterval: React.PropTypes.object,
+    xAxisTickValues:   React.PropTypes.array,
+    xOrient:           React.PropTypes.oneOf(['top', 'bottom']),
     yAccessor:         React.PropTypes.func,
-    title:             React.PropTypes.string
+    yAxisFormatter:    React.PropTypes.func,
+    yAxisLabel:        React.PropTypes.string,
+    yAxisLabelOffset:  React.PropTypes.number,
+    yAxisTickCount:    React.PropTypes.number,
+    yAxisTickInterval: React.PropTypes.object,
+    yAxisTickValues:   React.PropTypes.array,
+    yOrient:           React.PropTypes.oneOf(['left', 'right'])
   },
 
   getDefaultProps: function() {
     return {
-      data:             [],
-      xOrient:          'bottom',
-      xAxisLabel:       '',
-      xAxisLabelOffset: 38,
-      yOrient:          'left',
-      yAxisLabel:       '',
-      yAxisLabelOffset: 35,
-      legend:           false,
-      legendOffset:     120,
-      width:            400,
-      height:           200,
       axesColor:        '#000',
-      title:            '',
       colors:           d3.scale.category20c(),
       colorAccessor:    (d, idx) => idx,
+      height:           200,
+      legend:           false,
+      legendOffset:     120,
+      title:            '',
+      width:            400,
       xAccessor:        (d) => d.x,
-      yAccessor:        (d) => d.y
+      // xAxisFormatter: no predefined value right now
+      xAxisLabel:       '',
+      xAxisLabelOffset: 38,
+      // xAxisTickCount: no predefined value right now
+      // xAxisTickInterval: no predefined value right now
+      // xAxisTickValues: no predefined value right now
+      xOrient:          'bottom',
+      yAccessor:        (d) => d.y,
+      // yAxisFormatter: no predefined value right now
+      yAxisLabel:       '',
+      yAxisLabelOffset: 35,
+      // yAxisTickCount: no predefined value right now
+      // yAxisTickInterval: no predefined value right now
+      // yAxisTickValues: no predefined value right now
+      yOrient:          'left'
     };
   }
 };

--- a/tests/areachart-tests.js
+++ b/tests/areachart-tests.js
@@ -1,34 +1,8 @@
 'use strict';
 
-var expect = require('chai').expect;  
+var expect = require('chai').expect;
 
 describe('AreaChart', function() {
-  it('renders areachart', function() {
-    var React = require('react/addons');
-    var AreaChart = require('../src/areachart').AreaChart;
-    var generate = require('./utils/datagen').generateArrayOfObjects;
-    var TestUtils = React.addons.TestUtils;
-
-    // Render a areachart using single-series data object
-    var data = {
-      name: 'blah',
-      values: generate(5)
-    };
-
-    var areachart = TestUtils.renderIntoDocument(
-      <AreaChart data={data} width={400} height={200} />
-    );
-
-    var areachartGroup = TestUtils.findRenderedDOMComponentWithClass(
-      areachart, 'rd3-areachart');
-    expect(areachartGroup).to.exist;
-    expect(areachartGroup.tagName).to.equal('G');
-
-    var area = TestUtils.findRenderedDOMComponentWithClass(
-      areachart, 'rd3-areachart-area');
-    expect(area.props.d).to.exist;
-  });
-
   it('renders stacked areachart with array of objects data', function() {
     var React = require('react/addons');
     var AreaChart = require('../src/areachart').AreaChart;

--- a/tests/legend-tests.js
+++ b/tests/legend-tests.js
@@ -22,10 +22,11 @@ describe('Legend', function() {
     ];
 
     var legend = TestUtils.renderIntoDocument(
-      <Legend 
+      <Legend
         data={data}
         margins={{top: 10, right: 20, bottom: 30, left: 30}}
-      /> 
+        width={90}
+      />
     );
 
     // Verify that legend list exists

--- a/tests/linechart-tests.js
+++ b/tests/linechart-tests.js
@@ -3,33 +3,6 @@
 var expect = require('chai').expect;
 
 describe('LineChart', function() {
-  it('renders linechart property with object data', function() {
-    var React = require('react/addons');
-    var LineChart = require('../src/linechart').LineChart;
-    var generate = require('./utils/datagen').generateArrayOfPoints;
-    var TestUtils = React.addons.TestUtils;
-
-    // Render a linechart using array data
-    var data = {
-      name: 'blah',
-      values: generate(5)
-    };
-
-    var linechart = TestUtils.renderIntoDocument(
-      <LineChart data={data} width={400} height={200} />
-    );
-
-    var linechartGroup = TestUtils.findRenderedDOMComponentWithClass(
-      linechart, 'rd3-linechart');
-    expect(linechartGroup).to.exist;
-    expect(linechartGroup.tagName).to.equal('G');
-
-    // Verify that it has the same number of bars as the array's length
-    var paths = TestUtils.scryRenderedDOMComponentsWithClass(
-      linechart, 'rd3-linechart-path');
-    expect(paths).to.have.length(1);
-
-  });
   it('renders multi-series linechart with array of objects data', function() {
     var React = require('react/addons');
     var LineChart = require('../src/linechart').LineChart;


### PR DESCRIPTION
This stems from #225 , but it goes a bit farther, but also doesn't do everything the OP in #225 wanted.

1. This adds a `className` to every chart component. `className` is only exposed to the parent of the component - it would be too ugly right now to expose all the class names on the top-level chart, and, the names are unique enough that they should make due for basically all users; I will document the names at some point.
2. **Important: breaking change**: as part of going through all the Chart props, I also went through and **removed supporting `data` being an object - it MUST be an array now**. I think this change is worth it. It makes the code a lot simpler, and allows us to not have to do gimmicky checks and casts which may or may not work. If the user can't figure out that they need to wrap their object(s) in an array, they have much bigger problems - we can only babysit so much.
3. As you can see in this pr, and in #228 , I have started organizing props alphabetically. I think this should be done for every component. It makes props much easier to find and maintain.
4. I added missing `propTypes` and `getDefaultProps` where needed
5. I started the process of converting number-sounding-properties that are actually strings to be numbers. For example, `strokeWidth` in `Label`. While it needs to be a string, intuitively it seems like a number should be supplied. So, I made it so that it takes a number and converts it to a string when actually used.
6. I converted es6 string templates to normal es5 string concatenations. Most places in the code use concatenations, and imho, the templates are a real eye-sore and most contributors won't even know what they are - took me 30 minutes to figure it out since I was thinking someone had accidentally dumped some PHP code into the library, or that $ was doing dereferencing that I didn't know was possible.