### PR TITLE
Refactoring of ScatterChart code + minor changes to utils.flattenData

### DIFF
--- a/src/scatterchart/DataSeries.jsx
+++ b/src/scatterchart/DataSeries.jsx
@@ -9,60 +9,65 @@ module.exports = React.createClass({
   displayName: 'DataSeries',
 
   propTypes: {
-    data: React.PropTypes.array,
-    fill: React.PropTypes.string,
-    xAccessor: React.PropTypes.func,
-    yAccessor: React.PropTypes.func,
-    colorAccessor: React.PropTypes.func
+    circleRadius:  React.PropTypes.number.isRequired,
+    colors:        React.propTypes.func.isRequired,
+    colorAccessor: React.PropTypes.func.isRequired,
+    data:          React.PropTypes.array.isRequired,
+    height:        React.PropTypes.number.isRequired,
+    xAccessor:     React.PropTypes.func.isRequired,
+    xScale:        React.PropTypes.func.isRequired,
+    yAccessor:     React.PropTypes.func.isRequired,
+    yScale:        React.PropTypes.func.isRequired
   },
 
   getDefaultProps() {
     return {
-      data: [],
-      fill: '#fff',
-      xAccessor: (d) => d.x,
-      yAccessor: (d) => d.y
+      data: []
     };
   },
-  
+
   render: function() {
-    var props = this.props;
-    var xScale = props.xScale;
-    var yScale = props.yScale;
-    var xAccessor = props.xAccessor,
-        yAccessor = props.yAccessor,
-        cx, cy, circleFill;
+    var props     = this.props;
+    var xScale    = props.xScale;
+    var yScale    = props.yScale;
+    var xAccessor = props.xAccessor;
+    var yAccessor = props.yAccessor;
 
     var voronoi = d3.geom.voronoi()
       .x(function(d){ return xScale(d.coord.x); })
       .y(function(d){ return yScale(d.coord.y); })
       .clipExtent([[0, 0], [ props.width , props.height]]);
 
-    var regions = voronoi(this.props.data).map(function(vnode, idx) {
+    var regions = voronoi(props.data).map(function(vnode, idx) {
       var point = vnode.point.coord;
+      var cx, cy;
+
       if (Object.prototype.toString.call(xAccessor(point)) === '[object Date]') {
-        cx = props.xScale(xAccessor(point).getTime());
+        cx = xScale(xAccessor(point).getTime());
       } else {
-        cx = props.xScale(xAccessor(point));
-      }
-      if (Object.prototype.toString.call(yAccessor(point)) === '[object Date]') {
-        cy = props.yScale(yAccessor(point).getTime());
-      } else {
-        cy = props.yScale(yAccessor(point));
+        cx = xScale(xAccessor(point));
       }
 
-      circleFill = props.colors(props.colorAccessor(vnode.point.seriesName, idx));
-      
+      if (Object.prototype.toString.call(yAccessor(point)) === '[object Date]') {
+        cy = yScale(yAccessor(point).getTime());
+      } else {
+        cy = yScale(yAccessor(point));
+      }
+
       return (
-          <VoronoiCircleContainer 
-              key={idx} circleFill={circleFill} vnode={vnode}
-              cx={cx} cy={cy} circleRadius={props.circleRadius}
-          />
+        <VoronoiCircleContainer
+          key={idx}
+          circleFill={props.colors(props.colorAccessor(vnode.point.d, idx))}
+          circleRadius={props.circleRadius}
+          cx={cx}
+          cy={cy}
+          vnode={vnode}
+        />
       );
-    }.bind(this));
+    });
 
     return (
-      <g id="voronoi">
+      <g>
         {regions}
       </g>
     );

--- a/src/scatterchart/DataSeries.jsx
+++ b/src/scatterchart/DataSeries.jsx
@@ -10,7 +10,8 @@ module.exports = React.createClass({
 
   propTypes: {
     circleRadius:  React.PropTypes.number.isRequired,
-    colors:        React.propTypes.func.isRequired,
+    className:     React.PropTypes.string,
+    colors:        React.PropTypes.func.isRequired,
     colorAccessor: React.PropTypes.func.isRequired,
     data:          React.PropTypes.array.isRequired,
     height:        React.PropTypes.number.isRequired,
@@ -22,7 +23,7 @@ module.exports = React.createClass({
 
   getDefaultProps() {
     return {
-      data: []
+      className: 'rd3-scatterchart-dataseries'
     };
   },
 
@@ -39,25 +40,31 @@ module.exports = React.createClass({
       .clipExtent([[0, 0], [ props.width , props.height]]);
 
     var regions = voronoi(props.data).map(function(vnode, idx) {
-      var point = vnode.point.coord;
+      var point = vnode.point;
+      var coord = point.coord;
+
+      var x = xAccessor(coord);
+      var y = yAccessor(coord);
+
+      // The circle coordinates
       var cx, cy;
 
-      if (Object.prototype.toString.call(xAccessor(point)) === '[object Date]') {
-        cx = xScale(xAccessor(point).getTime());
+      if (Object.prototype.toString.call(x) === '[object Date]') {
+        cx = xScale(x.getTime());
       } else {
-        cx = xScale(xAccessor(point));
+        cx = xScale(x);
       }
 
-      if (Object.prototype.toString.call(yAccessor(point)) === '[object Date]') {
-        cy = yScale(yAccessor(point).getTime());
+      if (Object.prototype.toString.call(y) === '[object Date]') {
+        cy = yScale(y.getTime());
       } else {
-        cy = yScale(yAccessor(point));
+        cy = yScale(y);
       }
 
       return (
         <VoronoiCircleContainer
           key={idx}
-          circleFill={props.colors(props.colorAccessor(vnode.point.d, idx))}
+          circleFill={props.colors(props.colorAccessor(point.d, point.seriesIndex))}
           circleRadius={props.circleRadius}
           cx={cx}
           cy={cy}
@@ -67,7 +74,9 @@ module.exports = React.createClass({
     });
 
     return (
-      <g>
+      <g
+        className={props.className}
+      >
         {regions}
       </g>
     );

--- a/src/scatterchart/ScatterChart.jsx
+++ b/src/scatterchart/ScatterChart.jsx
@@ -14,21 +14,26 @@ module.exports = React.createClass({
   displayName: 'ScatterChart',
 
   propTypes: {
-    circleRadius:   React.PropTypes.number,
-    hoverAnimation: React.PropTypes.bool,
-    margins:        React.PropTypes.object
+    circleRadius:     React.PropTypes.number,
+    className:        React.PropTypes.string,
+    hoverAnimation:   React.PropTypes.bool,
+    margins:          React.PropTypes.object,
+    xAxisClassName:   React.PropTypes.string,
+    xAxisStrokeWidth: React.PropTypes.number,
+    yAxisClassName:   React.PropTypes.string,
+    yAxisStrokeWidth: React.PropTypes.number
  },
 
   getDefaultProps() {
     return {
-      chartClassName:   'rd3-scatterchart',
       circleRadius:     3,
+      className:        'rd3-scatterchart',
       hoverAnimation:   true,
       margins:          {top: 10, right: 20, bottom: 50, left: 45},
       xAxisClassName:   'rd3-scatterchart-xaxis',
-      xAxisStrokeWidth: '1',
+      xAxisStrokeWidth: 1,
       yAxisClassName:   'rd3-scatterchart-yaxis',
-      yAxisStrokeWidth: '1'
+      yAxisStrokeWidth: 1
     };
   },
 
@@ -73,8 +78,8 @@ module.exports = React.createClass({
         width={props.width}
       >
         <g
+          className={props.className}
           transform={transform}
-          className={props.chartClassName}
         >
           <DataSeries
             circleRadius={props.circleRadius}
@@ -84,17 +89,17 @@ module.exports = React.createClass({
             height={innerHeight}
             hoverAnimation={props.hoverAnimation}
             width={innerWidth}
-            xScale={xScale}
-            yScale={yScale}
             xAccessor={props.xAccessor}
+            xScale={xScale}
             yAccessor={props.yAccessor}
+            yScale={yScale}
           />
           <XAxis
             data={data}
             height={innerHeight}
             margins={props.margins}
             stroke={props.axesColor}
-            strokeWidth={props.xAxisStrokeWidth}
+            strokeWidth={props.xAxisStrokeWidth.toString()}
             tickFormatting={props.xAxisFormatter}
             width={innerWidth}
             xAxisClassName={props.xAxisClassName}
@@ -112,7 +117,7 @@ module.exports = React.createClass({
             height={innerHeight}
             margins={props.margins}
             stroke={props.axesColor}
-            strokeWidth={props.yAxisStrokeWidth}
+            strokeWidth={props.yAxisStrokeWidth.toString()}
             tickFormatting={props.yAxisFormatter}
             yAxisClassName={props.yAxisClassName}
             yAxisLabel={props.yAxisLabel}

--- a/src/scatterchart/ScatterChart.jsx
+++ b/src/scatterchart/ScatterChart.jsx
@@ -43,14 +43,15 @@ module.exports = React.createClass({
 
     var props = this.props;
     var data  = props.data;
+    var margins = props.margins;
 
-    if (!data || !Array.isArray(data) || data.length < 1) {
+    if (!data || data.length < 1) {
       return null;
     }
 
     // Calculate inner chart dimensions
-    var innerWidth  = this.getOuterDimensions().width - props.margins.left - props.margins.right;
-    var innerHeight = this.getOuterDimensions().height - props.margins.top - props.margins.bottom;
+    var innerWidth  = this.getOuterDimensions().width - margins.left - margins.right;
+    var innerHeight = this.getOuterDimensions().height - margins.top - margins.bottom;
 
     // Returns an object of flattened allValues, xValues, and yValues
     var flattenedData = utils.flattenData(data, props.xAccessor, props.yAccessor);
@@ -63,7 +64,8 @@ module.exports = React.createClass({
     var xScale  = scales.xScale;
     var yScale  = scales.yScale;
 
-    var transform = 'translate(' + (props.yAxisOffset < 0 ? props.margins.left + Math.abs(props.yAxisOffset) : props.margins.left) + ',' + props.margins.top + ')';
+    var x = props.yAxisOffset < 0 ? (margins.left + Math.abs(props.yAxisOffset)) : margins.left;
+    var transform = `translate(${x}, ${margins.top})`;
 
     return (
       <Chart
@@ -72,7 +74,7 @@ module.exports = React.createClass({
         data={data}
         height={props.height}
         legend={props.legend}
-        margins={props.margins}
+        margins={margins}
         title={props.title}
         viewBox={this.getViewBox()}
         width={props.width}
@@ -97,7 +99,7 @@ module.exports = React.createClass({
           <XAxis
             data={data}
             height={innerHeight}
-            margins={props.margins}
+            margins={margins}
             stroke={props.axesColor}
             strokeWidth={props.xAxisStrokeWidth.toString()}
             tickFormatting={props.xAxisFormatter}
@@ -115,7 +117,7 @@ module.exports = React.createClass({
             data={data}
             width={innerWidth}
             height={innerHeight}
-            margins={props.margins}
+            margins={margins}
             stroke={props.axesColor}
             strokeWidth={props.yAxisStrokeWidth.toString()}
             tickFormatting={props.yAxisFormatter}

--- a/src/scatterchart/ScatterChart.jsx
+++ b/src/scatterchart/ScatterChart.jsx
@@ -14,16 +14,21 @@ module.exports = React.createClass({
   displayName: 'ScatterChart',
 
   propTypes: {
-    margins:        React.PropTypes.object,
     circleRadius:   React.PropTypes.number,
-    hoverAnimation: React.PropTypes.bool
+    hoverAnimation: React.PropTypes.bool,
+    margins:        React.PropTypes.object
  },
 
   getDefaultProps() {
     return {
-      circleRadius:    3,
-      margins:        {top: 10, right: 20, bottom: 50, left: 45},
-      hoverAnimation: true
+      chartClassName:   'rd3-scatterchart',
+      circleRadius:     3,
+      hoverAnimation:   true,
+      margins:          {top: 10, right: 20, bottom: 50, left: 45},
+      xAxisClassName:   'rd3-scatterchart-xaxis',
+      xAxisStrokeWidth: '1',
+      yAxisClassName:   'rd3-scatterchart-yaxis',
+      yAxisStrokeWidth: '1'
     };
   },
 
@@ -32,86 +37,91 @@ module.exports = React.createClass({
   render() {
 
     var props = this.props;
+    var data  = props.data;
 
-    if (this.props.data && this.props.data.length < 1) {
-      return <g></g>;
+    if (!data || !Array.isArray(data) || data.length < 1) {
+      return null;
     }
 
     // Calculate inner chart dimensions
-    var innerWidth, innerHeight;
-
-    innerWidth = this.getOuterDimensions().width - props.margins.left - props.margins.right;
-    innerHeight = this.getOuterDimensions().height - props.margins.top - props.margins.bottom;
-
-    if (!Array.isArray(props.data)) {
-      props.data = [props.data];
-    }
+    var innerWidth  = this.getOuterDimensions().width - props.margins.left - props.margins.right;
+    var innerHeight = this.getOuterDimensions().height - props.margins.top - props.margins.bottom;
 
     // Returns an object of flattened allValues, xValues, and yValues
-    var flattenedData = utils.flattenData(props.data, props.xAccessor, props.yAccessor);
+    var flattenedData = utils.flattenData(data, props.xAccessor, props.yAccessor);
 
     var allValues = flattenedData.allValues,
-        xValues = flattenedData.xValues,
-        yValues = flattenedData.yValues;
-    var scales = this._calculateScales(innerWidth, innerHeight, xValues, yValues);
-    var trans = "translate(" + (props.yAxisOffset < 0 ? props.margins.left + Math.abs(props.yAxisOffset) : props.margins.left) + "," + props.margins.top + ")";
+        xValues   = flattenedData.xValues,
+        yValues   = flattenedData.yValues;
+
+    var scales  = this._calculateScales(innerWidth, innerHeight, xValues, yValues);
+    var xScale  = scales.xScale;
+    var yScale  = scales.yScale;
+
+    var transform = 'translate(' + (props.yAxisOffset < 0 ? props.margins.left + Math.abs(props.yAxisOffset) : props.margins.left) + ',' + props.margins.top + ')';
 
     return (
       <Chart
-        viewBox={this.getViewBox()}
-        legend={props.legend}
-        data={props.data}
-        margins={props.margins}
         colors={props.colors}
         colorAccessor={props.colorAccessor}
-        width={props.width}
+        data={data}
         height={props.height}
-        title={props.title}>
-        <g transform={trans} className='rd3-scatterchart'>
+        legend={props.legend}
+        margins={props.margins}
+        title={props.title}
+        viewBox={this.getViewBox()}
+        width={props.width}
+      >
+        <g
+          transform={transform}
+          className={props.chartClassName}
+        >
           <DataSeries
-            xScale={scales.xScale}
-            yScale={scales.yScale}
+            circleRadius={props.circleRadius}
+            colors={props.colors}
+            colorAccessor={props.colorAccessor}
+            data={allValues}
+            height={innerHeight}
+            hoverAnimation={props.hoverAnimation}
+            width={innerWidth}
+            xScale={xScale}
+            yScale={yScale}
             xAccessor={props.xAccessor}
             yAccessor={props.yAccessor}
-            hoverAnimation={props.hoverAnimation}
-            circleRadius={props.circleRadius}
-            data={allValues}
-            colors={props.colors}
-            colorAccessor={(d, i) => d}
-            width={innerWidth}
-            height={innerHeight}
           />
           <XAxis
-            xAxisClassName="rd3-scatterchart-xaxis"
-            strokeWidth="1"
-            xAxisTickValues={props.xAxisTickValues}
-            xAxisTickInterval={props.xAxisTickInterval}
-            xAxisOffset={props.xAxisOffset}
-            xScale={scales.xScale}
+            data={data}
+            height={innerHeight}
+            margins={props.margins}
+            stroke={props.axesColor}
+            strokeWidth={props.xAxisStrokeWidth}
+            tickFormatting={props.xAxisFormatter}
+            width={innerWidth}
+            xAxisClassName={props.xAxisClassName}
             xAxisLabel={props.xAxisLabel}
             xAxisLabelOffset={props.xAxisLabelOffset}
-            tickFormatting={props.xAxisFormatter}
+            xAxisOffset={props.xAxisOffset}
+            xAxisTickInterval={props.xAxisTickInterval}
+            xAxisTickValues={props.xAxisTickValues}
             xOrient={props.xOrient}
-            data={props.data}
-            margins={props.margins}
-            width={innerWidth}
-            height={innerHeight}
-            stroke={props.axesColor}
+            xScale={xScale}
           />
           <YAxis
-            yAxisClassName="rd3-scatterchart-yaxis"
-            yScale={scales.yScale}
-            yAxisTickValues={props.yAxisTickValues}
-            yAxisTickCount={props.yAxisTickCount}
-            yAxisOffset={props.yAxisOffset}
-            yAxisLabel={props.yAxisLabel}
-            yAxisLabelOffset={props.yAxisLabelOffset}
-            tickFormatting={props.yAxisFormatter}
-            yOrient={props.yOrient}
-            margins={props.margins}
+            data={data}
             width={innerWidth}
             height={innerHeight}
+            margins={props.margins}
             stroke={props.axesColor}
+            strokeWidth={props.yAxisStrokeWidth}
+            tickFormatting={props.yAxisFormatter}
+            yAxisClassName={props.yAxisClassName}
+            yAxisLabel={props.yAxisLabel}
+            yAxisLabelOffset={props.yAxisLabelOffset}
+            yAxisOffset={props.yAxisOffset}
+            yAxisTickValues={props.yAxisTickValues}
+            yAxisTickCount={props.yAxisTickCount}
+            yScale={yScale}
+            yOrient={props.yOrient}
           />
         </g>
       </Chart>

--- a/src/scatterchart/VoronoiCircle.jsx
+++ b/src/scatterchart/VoronoiCircle.jsx
@@ -7,30 +7,44 @@ module.exports = React.createClass({
 
   displayName: 'VoronoiCircle',
 
+  propTypes: {
+    circleFill:       React.PropTypes.string.isRequired,
+    circleRadius:     React.PropTypes.number.isRequired,
+    className:        React.PropTypes.string,
+    cx:               React.PropTypes.number.isRequired,
+    cy:               React.PropTypes.number.isRequired,
+    handleMouseLeave: React.PropTypes.func.isRequired,
+    handleMouseOver:  React.PropTypes.func.isRequired,
+    pathFill:         React.PropTypes.string,
+    voronoiPath:      React.PropTypes.string.isRequired
+  },
+
   getDefaultProps() {
-    return { 
-      circleRadius: 3,
-      circleFill: '#1f77b4',
+    return {
+      className:    'rd3-scatterchart-voronoi-circle',
+      pathFill:     'white'
     };
   },
 
   render() {
+    var props = this.props;
+
     return (
       <g>
         <path
-          onMouseOver={this.props.handleMouseOver}
-          onMouseLeave={this.props.handleMouseLeave}
-          fill='white'
-          d={this.props.voronoiPath} 
+          d={props.voronoiPath}
+          fill={props.pathFill}
+          onMouseLeave={props.handleMouseLeave}
+          onMouseOver={props.handleMouseOver}
         />
         <circle
-          onMouseOver={this.props.handleMouseOver}
-          onMouseLeave={this.props.handleMouseLeave}
-          cx={this.props.cx}
-          cy={this.props.cy}
-          r={this.props.circleRadius}
-          fill={this.props.circleFill}
-          className="rd3-scatterchart-circle"
+          cx={props.cx}
+          cy={props.cy}
+          className={props.className}
+          fill={props.circleFill}
+          onMouseLeave={props.handleMouseLeave}
+          onMouseOver={props.handleMouseOver}
+          r={props.circleRadius}
         />
       </g>
     );

--- a/src/scatterchart/VoronoiCircleContainer.jsx
+++ b/src/scatterchart/VoronoiCircleContainer.jsx
@@ -47,14 +47,15 @@ module.exports = React.createClass({
   render() {
 
     var props = this.props;
+    var state = this.state;
 
     return (
       <g
         className={props.className}
       >
         <VoronoiCircle
-          circleFill={this.state.circleFill}
-          circleRadius={this.state.circleRadius}
+          circleFill={state.circleFill}
+          circleRadius={state.circleRadius}
           cx={props.cx}
           cy={props.cy}
           handleMouseLeave={this._restoreCircle}
@@ -71,7 +72,7 @@ module.exports = React.createClass({
     if(props.hoverAnimation) {
       this.setState({
         circleFill:   shade(props.circleFill, props.shadeMultiplier),
-        circleRadius: props.circleRadius * props.circleRadiusMultiplyer,
+        circleRadius: props.circleRadius * props.circleRadiusMultiplier
       });
     }
   },
@@ -79,10 +80,10 @@ module.exports = React.createClass({
   _restoreCircle() {
     var props = this.props;
 
-    if(this.props.hoverAnimation) {
+    if(props.hoverAnimation) {
       this.setState({
-        circleFill:   this.props.circleFill
-        circleRadius: this.props.circleRadius
+        circleFill:   props.circleFill,
+        circleRadius: props.circleRadius
       });
     }
   },

--- a/src/scatterchart/VoronoiCircleContainer.jsx
+++ b/src/scatterchart/VoronoiCircleContainer.jsx
@@ -9,69 +9,89 @@ module.exports = React.createClass({
 
   displayName: 'VornoiCircleContainer',
 
+  propTypes: {
+    circleFill:             React.PropTypes.string,
+    circleRadius:           React.PropTypes.number,
+    circleRadiusMultiplier: React.PropTypes.number,
+    className:              React.PropTypes.string,
+    hoverAnimation:         React.PropTypes.bool,
+    shadeMultiplier:        React.PropTypes.number,
+    vnode:                  React.PropTypes.array.isRequired
+  },
+
   getDefaultProps() {
-    return { 
-      circleRadius: 3,
-      circleFill: '#1f77b4',
-      hoverAnimation: true
+    return {
+      circleFill:             '#1f77b4',
+      circleRadius:           3,
+      circleRadiusMultiplier: 1.25,
+      className:              'rd3-scatterchart-voronoi-circle-container',
+      hoverAnimation:         true,
+      shadeMultiplier:        0.2
     };
   },
 
   getInitialState() {
-    return { 
-      circleRadius: this.props.circleRadius,
-      circleFill: this.props.circleFill
+    return {
+      circleFill:   this.props.circleFill,
+      circleRadius: this.props.circleRadius
     }
+  },
 
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      circleFill:   nextProps.circleFill,
+      circleRadius: nextProps.circleRadius
+    });
   },
 
   render() {
 
     var props = this.props;
 
-    // animation controller
-    var handleMouseOver, handleMouseLeave;
-    if(props.hoverAnimation) {
-      handleMouseOver = this._animateCircle;
-      handleMouseLeave = this._restoreCircle;
-    } else {
-      handleMouseOver = handleMouseLeave = null;
-    }
-
     return (
-      <g>
+      <g
+        className={props.className}
+      >
         <VoronoiCircle
-            handleMouseOver={handleMouseOver}
-            handleMouseLeave={handleMouseLeave}
-            voronoiPath={this._drawPath(props.vnode)}
-            cx={props.cx}
-            cy={props.cy}
-            circleRadius={this.state.circleRadius}
-            circleFill={this.state.circleFill}
-            className="rd3-scatterchart-circle"
+          circleFill={this.state.circleFill}
+          circleRadius={this.state.circleRadius}
+          cx={props.cx}
+          cy={props.cy}
+          handleMouseLeave={this._restoreCircle}
+          handleMouseOver={this._animateCircle}
+          voronoiPath={this._drawPath(props.vnode)}
         />
       </g>
     );
   },
 
   _animateCircle() {
-    this.setState({ 
-      circleRadius: this.props.circleRadius * ( 5 / 4 ),
-      circleFill: shade(this.props.circleFill, 0.2)
-    });
+    var props = this.props;
+
+    if(props.hoverAnimation) {
+      this.setState({
+        circleFill:   shade(props.circleFill, props.shadeMultiplier),
+        circleRadius: props.circleRadius * props.circleRadiusMultiplyer,
+      });
+    }
   },
 
   _restoreCircle() {
-    this.setState({ 
-      circleRadius: this.props.circleRadius,
-      circleFill: this.props.circleFill
-    });
+    var props = this.props;
+
+    if(this.props.hoverAnimation) {
+      this.setState({
+        circleFill:   this.props.circleFill
+        circleRadius: this.props.circleRadius
+      });
+    }
   },
 
   _drawPath: function(d) {
-    if(d === undefined) {
-      return; 
-    }  
+    if(typeof d === 'undefined') {
+      return 'M Z';
+    }
+
     return 'M' + d.join(',') + 'Z';
   },
 });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -117,8 +117,8 @@ exports.flattenData = (data, xAccessor, yAccessor) => {
         },
         d: item,
         id: series.name + j,
-        seriesIndex: i,
-        seriesName: series.name
+        series: series,
+        seriesIndex: i
       };
       allValues.push(pointItem);
     });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -59,8 +59,8 @@ exports.flattenData = (data, xAccessor, yAccessor) => {
   var yValues = [];
   var coincidentCoordinateCheck = {};
 
-  data.forEach( (series) => {
-    series.values.forEach( (item, idx) => {
+  data.forEach( (series, i) => {
+    series.values.forEach( (item, j) => {
 
       var x = xAccessor(item);
 
@@ -100,8 +100,8 @@ exports.flattenData = (data, xAccessor, yAccessor) => {
         yNode = y;
       }
 
-      var xyCoords = `${ x }-${ yNode }`;
-      if (xyCoords in coincidentCoordinateCheck) {
+      var xyCoords = x + '-' + yNode;
+      if (coincidentCoordinateCheck.hasOwnProperty(xyCoords)) {
         // Proceed to next iteration if the x y pair already exists
         // d3's Voronoi cannot handle NaN values or coincident coords
         // But we push them into xValues and yValues above because
@@ -109,12 +109,15 @@ exports.flattenData = (data, xAccessor, yAccessor) => {
         return;
       }
       coincidentCoordinateCheck[xyCoords] = '';
+
       var pointItem = {
         coord: {
           x: x,
           y: yNode,
         },
-        id: `${ series.name }-${ idx }`,
+        d: item,
+        id: series.name + j,
+        seriesIndex: i,
         seriesName: series.name
       };
       allValues.push(pointItem);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -100,7 +100,7 @@ exports.flattenData = (data, xAccessor, yAccessor) => {
         yNode = y;
       }
 
-      var xyCoords = x + '-' + yNode;
+      var xyCoords = `${x}-${yNode}`;
       if (coincidentCoordinateCheck.hasOwnProperty(xyCoords)) {
         // Proceed to next iteration if the x y pair already exists
         // d3's Voronoi cannot handle NaN values or coincident coords

--- a/tests/scatterchart-tests.js
+++ b/tests/scatterchart-tests.js
@@ -10,10 +10,13 @@ var points = 5;
 var circleRadius = 5;
 var data, scatterchart;
 
+var CHART_CLASS_NAME  = 'rd3-scatterchart';
+var CIRCLE_CLASS_NAME = 'rd3-scatterchart-voronoi-circle';
+
 describe('ScatterChart', function() {
 
   before(function() {
-    // Render a scatterchart 
+    // Render a scatterchart
     data = [
       {
         name: "series1",
@@ -25,7 +28,12 @@ describe('ScatterChart', function() {
       }
     ];
     scatterchart = TestUtils.renderIntoDocument(
-      <ScatterChart data={data} width={400} height={200} circleRadius={circleRadius} />
+      <ScatterChart
+        circleRadius={circleRadius}
+        data={data}
+        width={400}
+        height={200}
+      />
     );
 
   })
@@ -33,7 +41,7 @@ describe('ScatterChart', function() {
   it('renders scatter chart', function() {
 
     var scatterchartGroup = TestUtils.findRenderedDOMComponentWithClass(
-      scatterchart, 'rd3-scatterchart');
+      scatterchart, CHART_CLASS_NAME);
     expect(scatterchartGroup).to.exist;
     expect(scatterchartGroup.tagName).to.equal('G');
 
@@ -42,22 +50,22 @@ describe('ScatterChart', function() {
   it('renders same amount of circles with data', function() {
 
     var circles = TestUtils.scryRenderedDOMComponentsWithClass(
-      scatterchart, 'rd3-scatterchart-circle');
+      scatterchart, CIRCLE_CLASS_NAME);
     expect(circles).to.have.length(Object.keys(data).length * points);
-  
+
   });
 
-  it('circle color is different from other series', function() {
+  it('each series has unique circle color', function() {
 
     var circles = TestUtils.scryRenderedDOMComponentsWithClass(
-      scatterchart, 'rd3-scatterchart-circle');
+      scatterchart, CIRCLE_CLASS_NAME);
 
     // uses this naive approach because TestUtils does not have
     // something like findRenderedDOMComponentWithProps
     var firstCircle = circles[0],
         secondCircle = circles[1],
         lastCircle = circles[circles.length - 1];
-    
+
     // we know that first and second circle are in same series
     expect(firstCircle.props.fill).to.equal(secondCircle.props.fill);
 
@@ -66,24 +74,30 @@ describe('ScatterChart', function() {
 
   });
 
-  it('circle is animated when hovered', function() {
+  it('circle animates correctly', function() {
 
       var circle = TestUtils.scryRenderedDOMComponentsWithClass(
-        scatterchart, 'rd3-scatterchart-circle')[0];
+        scatterchart, CIRCLE_CLASS_NAME)[0];
 
-      // circle color before hovered
-      var circleColor = circle.props.fill;
+      // circle properties before hovered
+      var circleColor  = circle.props.fill;
 
+      // Before animation
       expect(circle.props.r).to.equal(circleRadius);
+      expect(circle.props.fill).to.equal(circleColor);
+
+      // Animation starts with hover
       TestUtils.Simulate.mouseOver(circle);
       expect(circle.props.r).to.be.above(circleRadius);
       expect(circle.props.fill).to.not.equal(circleColor);
 
       // TestUtils.Simulate.mouseOut(circle) is not working here
       // https://github.com/facebook/react/issues/1297
+      // Animation ends with end of hover
       TestUtils.SimulateNative.mouseOut(circle);
       expect(circle.props.r).to.equal(circleRadius);
-      expect(circle.props.fill).to.equal(circleColor);    
+      expect(circle.props.fill).to.equal(circleColor);
+
   });
 
 });


### PR DESCRIPTION
This pr does some major refactoring to the `ScatterChart` code.

1. Fixes missing props, `propTypes`, and `getDefaultProps`
2. Fixes the bug where animation was making the component fail to respond to changes due to missing `componentWillReceiveProps`
3. Fixes non-standard calls to `colorAccessor`
4. Because data for `ScatterChart` goes through `utils.flattenData`, that method had to be modified to ensure that each record still retained all original data, and that each record knew from which series it came from.
5. `utils.flattenData` had a small potential bug fixed, replacing `in` with `hasOwnProperty`
6. Code across `ScatterChart` has been simplified
7. Based on #227 , support for `data` as an Object has been removed
8. "Magic constants" have been moved into `defaultProps`
9. Tests have been updated to support the above
10. es6 string templates were removed in favor of traditional es5 string concatenations. As I note in #227 , this is for standardization of the code base as well as maintainability

@yang-wei this is what the pr you submitted in #221 should look like. These changes are all the comments I made on that pr, plus some.