### PR TITLE
Exposed stroke-width and added stroke-dasharray support to line chart

### DIFF
--- a/docs/examples/main.js
+++ b/docs/examples/main.js
@@ -51,7 +51,9 @@ var Demos = React.createClass({
     var lineData = [
       { 
         name: 'series1',
-        values: [ { x: 0, y: 20 }, { x: 1, y: 30 }, { x: 2, y: 10 }, { x: 3, y: 5 }, { x: 4, y: 8 }, { x: 5, y: 15 }, { x: 6, y: 10 } ]
+        values: [ { x: 0, y: 20 }, { x: 1, y: 30 }, { x: 2, y: 10 }, { x: 3, y: 5 }, { x: 4, y: 8 }, { x: 5, y: 15 }, { x: 6, y: 10 } ],
+        strokeWidth: 3,
+        strokeDashArray: "5,5",
       },
       {
         name: 'series2',
@@ -116,7 +118,9 @@ var Demos = React.createClass({
 `var lineData = [
   {
     name: "series1",
-    values: [ { x: 0, y: 20 }, ..., { x: 24, y: 10 } ]
+    values: [ { x: 0, y: 20 }, ..., { x: 24, y: 10 } ],
+    strokeWidth: 3,
+    strokeDashArray: "5,5",
   },
   ....
   {

--- a/src/linechart/DataSeries.jsx
+++ b/src/linechart/DataSeries.jsx
@@ -57,6 +57,8 @@ module.exports = React.createClass({
         <Line 
           path={interpolatePath(series.values)}
           stroke={props.colors(props.colorAccessor(series, idx))}
+          strokeWidth={series.strokeWidth}
+          strokeDashArray={series.strokeDashArray}
           seriesName={series.name}
           key={idx}
         />

--- a/src/linechart/Line.jsx
+++ b/src/linechart/Line.jsx
@@ -12,6 +12,7 @@ module.exports = React.createClass({
     path: React.PropTypes.string,
     stroke: React.PropTypes.string,
     strokeWidth: React.PropTypes.number,
+    strokeDashArray: React.PropTypes.string,
   },
 
   getDefaultProps() {
@@ -30,6 +31,7 @@ module.exports = React.createClass({
         d={props.path}
         stroke={props.stroke}
         strokeWidth={props.strokeWidth}
+        strokeDasharray={props.strokeDashArray}
         fill={props.fill}
         className={props.className}
       />


### PR DESCRIPTION
I took this approach to adding `stroke-width` and `stroke-dasharray` props to LineChart. It is different from how we specify colors with a `colorAccessor` prop but seemed vastly simpler.

![screen shot 2015-06-24 at 10 52 09 am](https://cloud.githubusercontent.com/assets/327903/8337291/31be3af2-1a5f-11e5-97aa-1a71a11c06b9.png)
