### PR TITLE
fixes toString bug with single-digit RGB values in utils.shade

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -142,8 +142,11 @@ exports.shade = (hex, percent) => {
   G = number >> 8 & 0xFF;
   B = number & 0xFF;
   red = min( 255, round( ( 1 + percent ) * R )).toString(16);
+  if (red.length === 1) red = '0' + red;
   green = min( 255, round( ( 1 + percent ) * G )).toString(16);
+  if (green.length === 1) green = '0' + green;
   blue = min( 255, round( ( 1 + percent ) * B )).toString(16);
+  if (blue.length === 1) blue = '0' + blue;
   return `#${ red }${ green }${ blue }`;
 
 };


### PR DESCRIPTION
In utils.shade, if the values of red, green, or blue are single-digit, the resulting string may not be a proper hex string. Single digits need to be prepended with '0'.