### PR TITLE
InterpolationType for LineChart

### DIFF
--- a/src/linechart/LineChart.jsx
+++ b/src/linechart/LineChart.jsx
@@ -80,6 +80,7 @@ module.exports = React.createClass({
             circleRadius={props.circleRadius}
             data={props.data}
             value={allValues}
+            interpolationType={props.interpolationType}
             colors={props.colors}
             colorAccessor={props.colorAccessor}
             width={innerWidth}


### PR DESCRIPTION
Pass property `interpolationType` from `LineChart` to `DataSeries` to actually being able to use it.