### PR TITLE
Bugfix: Don't add h4 title element to chart if there is no title

### DIFF
--- a/src/common/charts/BasicChart.jsx
+++ b/src/common/charts/BasicChart.jsx
@@ -28,7 +28,7 @@ module.exports = React.createClass({
   _renderTitle() {
     var props = this.props;
 
-    if (props.title != null) {
+    if (props.title != '' && props.title != null) {
       return (
         <h4
           className={props.titleClassName}

--- a/src/common/charts/LegendChart.jsx
+++ b/src/common/charts/LegendChart.jsx
@@ -60,7 +60,7 @@ module.exports = React.createClass({
   _renderTitle() {
     var props = this.props;
 
-    if (props.title != null) {
+    if (props.title != '' && props.title != null) {
       return (
         <h4
           className={props.titleClassName}


### PR DESCRIPTION
Although I didn't set a title for the chart, there was the h4 `rd3-chart-title`
element in my DOM. In my case `this.props.title = ""` if I don't set a title.
However, this is not the case for phantom.js. Does that depend on the
browser version? I'm using Chrome and Firefox. Anyway, with the changes I
don't have the title element and the karma tests end successfully.