### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/examples/main.js
+++ b/docs/examples/main.js
@@ -273,12 +273,12 @@ var Demos = React.createClass({
   data={areaData}
   width="100%"
   height={300}
-  viewBoxObject={
+  viewBoxObject={{
     x: 0,
     y: 0,
-    heigth: 400,
+    height: 400,
     width: 500
-  }
+  }}
   xAxisTickInterval={{unit: 'year', interval: 2}}
   title="Area Chart"
 />`


### PR DESCRIPTION
There were a couple typos in the documentation for the area chart that cause the graph not to render. A misspelling of height and an object that was missing the extra set of {}.