### PR TITLE
Horizontal cartesian charts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{js,jsx}]
+indent_style = space
+indent_size = 2

--- a/src/areachart/AreaChart.jsx
+++ b/src/areachart/AreaChart.jsx
@@ -38,7 +38,7 @@ module.exports = React.createClass({
 
     var interpolationType = props.interpolationType || (props.interpolate ? 'cardinal' : 'linear');
 
-    var {innerWidth, innerHeight} = this.getDimensions();
+    var {innerWidth, innerHeight, trans} = this.getDimensions();
 
     if (!Array.isArray(data)) {
       data = [data];
@@ -82,8 +82,6 @@ module.exports = React.createClass({
       .values((d)=> { return d.values; });
 
     var layers = stack(data);
-
-    var trans = `translate(${ props.margins.left },${ props.margins.top })`;
 
     var dataSeries = layers.map( (d, idx) => {
       return (

--- a/src/areachart/AreaChart.jsx
+++ b/src/areachart/AreaChart.jsx
@@ -4,11 +4,11 @@ var React = require('react');
 var d3 = require('d3');
 var DataSeries = require('./DataSeries');
 var { Chart, XAxis, YAxis } = require('../common');
-var { CartesianChartPropsMixin, ViewBoxMixin } = require('../mixins');
+var { CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin } = require('../mixins');
 
 module.exports = React.createClass({
 
-  mixins: [ CartesianChartPropsMixin, ViewBoxMixin ],
+  mixins: [ CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin ],
 
   displayName: 'AreaChart',
 
@@ -38,7 +38,8 @@ module.exports = React.createClass({
 
     var interpolationType = props.interpolationType || (props.interpolate ? 'cardinal' : 'linear');
 
-    var {innerWidth, innerHeight, trans} = this.getDimensions();
+    var {innerWidth, innerHeight, trans, svgMargins} = this.getDimensions();
+    var yOrient = this.getYOrient();
 
     if (!Array.isArray(data)) {
       data = [data];
@@ -124,10 +125,11 @@ module.exports = React.createClass({
             xAxisLabelOffset={props.xAxisLabelOffset}
             tickFormatting={props.xAxisFormatter}
             xOrient={props.xOrient}
-            yOrient={props.yOrient}
-            margins={props.margins}
+            yOrient={yOrient}
+            margins={svgMargins}
             width={innerWidth}
             height={innerHeight}
+            horizontalChart={props.horizontal}
             gridVertical={props.gridVertical}
             gridVerticalStroke={props.gridVerticalStroke}
             gridVerticalStrokeWidth={props.gridVerticalStrokeWidth}
@@ -143,10 +145,11 @@ module.exports = React.createClass({
             yAxisLabelOffset={props.yAxisLabelOffset}
             tickFormatting={props.yAxisFormatter}
             xOrient={props.xOrient}
-            yOrient={props.yOrient}
-            margins={props.margins}
+            yOrient={yOrient}
+            margins={svgMargins}
             width={innerWidth}
             height={props.height}
+            horizontalChart={props.horizontal}
             gridHorizontal={props.gridHorizontal}
             gridHorizontalStroke={props.gridHorizontalStroke}
             gridHorizontalStrokeWidth={props.gridHorizontalStrokeWidth}

--- a/src/areachart/AreaChart.jsx
+++ b/src/areachart/AreaChart.jsx
@@ -38,10 +38,7 @@ module.exports = React.createClass({
 
     var interpolationType = props.interpolationType || (props.interpolate ? 'cardinal' : 'linear');
 
-    // Calculate inner chart dimensions
-    var innerWidth, innerHeight;
-    innerWidth = this.getOuterDimensions().width - props.margins.left - props.margins.right;
-    innerHeight = this.getOuterDimensions().height - props.margins.top - props.margins.bottom;
+    var {innerWidth, innerHeight} = this.getDimensions();
 
     if (!Array.isArray(data)) {
       data = [data];

--- a/src/barchart/BarChart.jsx
+++ b/src/barchart/BarChart.jsx
@@ -76,12 +76,14 @@ module.exports = React.createClass({
 
     var props = this.props;
 
+    var {height, width} = this.getOuterDimensions();
+
     var _data = this._stack()(props.data);
 
     var margins = props.margins;
 
-    var innerHeight = props.height - ( margins.top + margins.bottom );
-    var innerWidth = props.width - ( margins.left + margins.right );
+    var innerHeight = height - ( margins.top + margins.bottom );
+    var innerWidth = width - ( margins.left + margins.right );
 
     var xScale = d3.scale.ordinal()
       .domain(this._getLabels(_data[0]))
@@ -95,7 +97,7 @@ module.exports = React.createClass({
 
     return (
       <Chart
-        viewBox={props.viewBox}
+        viewBox={this.getViewBox()}
         legend={props.legend}
         data={props.data}
         margins={props.margins}

--- a/src/barchart/BarChart.jsx
+++ b/src/barchart/BarChart.jsx
@@ -80,7 +80,7 @@ module.exports = React.createClass({
 
     var margins = props.margins;
 
-    var {innerHeight, innerWidth} = this.getDimensions();
+    var {innerHeight, innerWidth, trans} = this.getDimensions();
 
     var xScale = d3.scale.ordinal()
       .domain(this._getLabels(_data[0]))
@@ -89,8 +89,6 @@ module.exports = React.createClass({
     var yScale = d3.scale.linear()
       .range([innerHeight, 0])
       .domain([0, this._getStackedValuesMaxY(_data)]);
-
-    var trans = `translate(${ margins.left },${ margins.top })`;
 
     return (
       <Chart

--- a/src/barchart/BarChart.jsx
+++ b/src/barchart/BarChart.jsx
@@ -76,14 +76,11 @@ module.exports = React.createClass({
 
     var props = this.props;
 
-    var {height, width} = this.getOuterDimensions();
-
     var _data = this._stack()(props.data);
 
     var margins = props.margins;
 
-    var innerHeight = height - ( margins.top + margins.bottom );
-    var innerWidth = width - ( margins.left + margins.right );
+    var {innerHeight, innerWidth} = this.getDimensions();
 
     var xScale = d3.scale.ordinal()
       .domain(this._getLabels(_data[0]))

--- a/src/barchart/BarChart.jsx
+++ b/src/barchart/BarChart.jsx
@@ -6,11 +6,11 @@ var DataSeries = require('./DataSeries');
 var utils = require('../utils');
 
 var { Chart, XAxis, YAxis } = require('../common');
-var { CartesianChartPropsMixin, ViewBoxMixin } = require('../mixins');
+var { CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin } = require('../mixins');
 
 module.exports = React.createClass({
 
-  mixins: [ CartesianChartPropsMixin, ViewBoxMixin ],
+  mixins: [ CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin ],
 
   displayName: 'BarChart',
 
@@ -75,12 +75,11 @@ module.exports = React.createClass({
   render() {
 
     var props = this.props;
+    var yOrient = this.getYOrient();
 
     var _data = this._stack()(props.data);
 
-    var margins = props.margins;
-
-    var {innerHeight, innerWidth, trans} = this.getDimensions();
+    var {innerHeight, innerWidth, trans, svgMargins} = this.getDimensions();
 
     var xScale = d3.scale.ordinal()
       .domain(this._getLabels(_data[0]))
@@ -109,13 +108,14 @@ module.exports = React.createClass({
             yAxisLabel={props.yAxisLabel}
             yAxisLabelOffset={props.yAxisLabelOffset}
             yScale={yScale}
-            margins={margins}
+            margins={svgMargins}
             yAxisTickCount={props.yAxisTickCount}
             tickFormatting={props.yAxisFormatter}
             width={innerWidth}
             height={innerHeight}
+            horizontalChart={props.horizontal}
             xOrient={props.xOrient}
-            yOrient={props.yOrient}
+            yOrient={yOrient}
             gridHorizontal={props.gridHorizontal}
             gridHorizontalStroke={props.gridHorizontalStroke}
             gridHorizontalStrokeWidth={props.gridHorizontalStrokeWidth}
@@ -127,12 +127,13 @@ module.exports = React.createClass({
             xAxisLabel={props.xAxisLabel}
             xAxisLabelOffset={props.xAxisLabelOffset} 
             xScale={xScale}
-            margins={margins}
+            margins={svgMargins}
             tickFormatting={props.xAxisFormatter}
             width={innerWidth}
             height={innerHeight}
+            horizontalChart={props.horizontal}
             xOrient={props.xOrient}
-            yOrient={props.yOrient}
+            yOrient={yOrient}
             gridVertical={props.gridVertical}
             gridVerticalStroke={props.gridVerticalStroke}
             gridVerticalStrokeWidth={props.gridVerticalStrokeWidth}
@@ -141,7 +142,7 @@ module.exports = React.createClass({
           <DataSeries
             yScale={yScale}
             xScale={xScale}
-            margins={margins}
+            margins={svgMargins}
             _data={_data}
             width={innerWidth}
             height={innerHeight}

--- a/src/candlestick/CandlestickChart.jsx
+++ b/src/candlestick/CandlestickChart.jsx
@@ -5,11 +5,11 @@ var d3 = require('d3');
 var utils = require('../utils');
 var DataSeries = require('./DataSeries');
 var { Chart, XAxis, YAxis } = require('../common');
-var { ViewBoxMixin } = require('../mixins');
+var { ViewBoxMixin, CartesianChartPropsMixin } = require('../mixins');
 
 module.exports = React.createClass({
 
-  mixins: [ ViewBoxMixin ],
+  mixins: [ CartesianChartPropsMixin, ViewBoxMixin ],
 
   displayName: 'CandleStickChart',
 
@@ -22,18 +22,13 @@ module.exports = React.createClass({
     fillUpAccessor:    React.PropTypes.func,
     fillDown:          React.PropTypes.func,
     fillDownAccessor:  React.PropTypes.func,
-    height:            React.PropTypes.number,
     hoverAnimation:    React.PropTypes.bool,
-    title:             React.PropTypes.string,
-    xAccessor:         React.PropTypes.func,
     xAxisFormatter:    React.PropTypes.func,
     xAxisTickInterval: React.PropTypes.object,
     xAxisTickValues:   React.PropTypes.array,
-    yAccessor:         React.PropTypes.func,
     yAxisFormatter:    React.PropTypes.func,
     yAxisTickCount:    React.PropTypes.number,
     yAxisTickValues:   React.PropTypes.array,
-    width:             React.PropTypes.number,
   },
 
   getDefaultProps() {
@@ -46,14 +41,10 @@ module.exports = React.createClass({
       fillUpAccessor:   (d, idx) => idx,
       fillDown:         d3.scale.category20c(),
       fillDownAccessor: (d, idx) => idx,
-      height:           200,
       hoverAnimation:   true,
       margins:          {top: 10, right: 20, bottom: 30, left: 45},
-      legendOffset:     120,
-      title:            '',
       xAccessor:        (d) => d.x,
       yAccessor:        (d) => ({ open: d.open, high: d.high, low: d.low, close: d.close }),
-      width:            400,
     };
   },
 
@@ -61,7 +52,8 @@ module.exports = React.createClass({
 
     var props = this.props;
 
-    var {innerWidth, innerHeight, trans} = this.getDimensions();
+    var {innerWidth, innerHeight, trans, svgMargins} = this.getDimensions();
+    var yOrient = this.getYOrient();
 
     if (!Array.isArray(props.data)) {
       props.data = [props.data];
@@ -110,10 +102,11 @@ module.exports = React.createClass({
             xAxisLabel={props.xAxisLabel}
             xAxisLabelOffset={props.xAxisLabelOffset}
             xOrient={props.xOrient}
-            yOrient={props.yOrient}
-            margins={props.margins}
+            yOrient={yOrient}
+            margins={svgMargins}
             width={innerWidth}
             height={innerHeight}
+            horizontalChart={props.horizontal}
             gridVertical={props.gridVertical}
             gridVerticalStroke={props.gridVerticalStroke}
             gridVerticalStrokeWidth={props.gridVerticalStrokeWidth}
@@ -129,10 +122,11 @@ module.exports = React.createClass({
             yAxisLabel={props.yAxisLabel}
             yAxisLabelOffset={props.yAxisLabelOffset}
             xOrient={props.xOrient}
-            yOrient={props.yOrient}
-            margins={props.margins}
+            yOrient={yOrient}
+            margins={svgMargins}
             width={innerWidth}
             height={props.height}
+            horizontalChart={props.horizontal}
             gridHorizontal={props.gridHorizontal}
             gridHorizontalStroke={props.gridHorizontalStroke}
             gridHorizontalStrokeWidth={props.gridHorizontalStrokeWidth}

--- a/src/candlestick/CandlestickChart.jsx
+++ b/src/candlestick/CandlestickChart.jsx
@@ -61,7 +61,7 @@ module.exports = React.createClass({
 
     var props = this.props;
 
-    var {innerWidth, innerHeight} = this.getDimensions();
+    var {innerWidth, innerHeight, trans} = this.getDimensions();
 
     if (!Array.isArray(props.data)) {
       props.data = [props.data];
@@ -72,8 +72,6 @@ module.exports = React.createClass({
         xValues = flattenedData.xValues,
         yValues = flattenedData.yValues;
     var scales = utils.calculateScales(innerWidth, innerHeight, xValues, yValues);
-
-    var trans = `translate(${ props.yAxisOffset < 0 ? props.margins.left + Math.abs(props.yAxisOffset) : props.margins.left},${ props.margins.top })`;
 
     var dataSeries = props.data.map( (series, idx) => {
       return (

--- a/src/candlestick/CandlestickChart.jsx
+++ b/src/candlestick/CandlestickChart.jsx
@@ -61,12 +61,7 @@ module.exports = React.createClass({
 
     var props = this.props;
 
-    var {height, width} = this.getOuterDimensions();
-
-    // Calculate inner chart dimensions
-    var innerWidth, innerHeight;
-    innerWidth = width - props.margins.left - props.margins.right;
-    innerHeight = height - props.margins.top - props.margins.bottom;
+    var {innerWidth, innerHeight} = this.getDimensions();
 
     if (!Array.isArray(props.data)) {
       props.data = [props.data];

--- a/src/candlestick/CandlestickChart.jsx
+++ b/src/candlestick/CandlestickChart.jsx
@@ -5,8 +5,11 @@ var d3 = require('d3');
 var utils = require('../utils');
 var DataSeries = require('./DataSeries');
 var { Chart, XAxis, YAxis } = require('../common');
+var { ViewBoxMixin } = require('../mixins');
 
 module.exports = React.createClass({
+
+  mixins: [ ViewBoxMixin ],
 
   displayName: 'CandleStickChart',
 
@@ -58,10 +61,12 @@ module.exports = React.createClass({
 
     var props = this.props;
 
+    var {height, width} = this.getOuterDimensions();
+
     // Calculate inner chart dimensions
     var innerWidth, innerHeight;
-    innerWidth = props.width - props.margins.left - props.margins.right;
-    innerHeight = props.height - props.margins.top - props.margins.bottom;
+    innerWidth = width - props.margins.left - props.margins.right;
+    innerHeight = height - props.margins.top - props.margins.bottom;
 
     if (!Array.isArray(props.data)) {
       props.data = [props.data];
@@ -95,7 +100,7 @@ module.exports = React.createClass({
 
     return (
       <Chart
-        viewBox={props.viewBox}
+        viewBox={this.getViewBox()}
         width={props.width}
         height={props.height}
         margins={props.margins}

--- a/src/common/axes/AxisTicks.jsx
+++ b/src/common/axes/AxisTicks.jsx
@@ -13,6 +13,7 @@ module.exports = React.createClass({
     orient2nd: React.PropTypes.oneOf(['top','bottom','left','right']),
     height: React.PropTypes.number.isRequired,
     width: React.PropTypes.number.isRequired,
+    horizontal: React.PropTypes.bool,
     tickArguments : React.PropTypes.array,
     tickValues: React.PropTypes.array,
     innerTickSize: React.PropTypes.number,
@@ -55,7 +56,9 @@ module.exports = React.createClass({
         ticks,
         scale,
         adjustedScale,
+        orient,
         textAnchor,
+        textTransform,
         tickFormat,
         y0, y1, y2, dy, x0, x1, x2, dx;
 
@@ -88,6 +91,7 @@ module.exports = React.createClass({
     }
 
     adjustedScale = scale.rangeBand ? (d) => { return scale(d) + scale.rangeBand() / 2; } : scale;
+
 
     // Still working on this
     // Ticks and lines are not fully aligned
@@ -131,6 +135,30 @@ module.exports = React.createClass({
         break;
     }
 
+    if (props.horizontalChart) {
+      textTransform = "rotate(-90)";
+      [y1, x1] = [x1, -y1 || 0];
+
+      switch (props.orient) {
+        case 'top':
+          textAnchor = "start";
+          dy = ".32em";
+          break;
+        case 'bottom':
+          textAnchor = "end";
+          dy = ".32em";
+          break;
+        case 'left':
+          textAnchor = 'middle';
+          dy = sign < 0 ? ".71em" : "0em";
+          break;
+        case 'right':
+          textAnchor = 'middle';
+          dy = sign < 0 ? ".71em" : "0em";
+          break;
+      }
+    }
+
     if (props.gridHorizontal) {
       gridOn = true;
       gridStrokeWidth = props.gridHorizontalStrokeWidth;
@@ -162,6 +190,10 @@ module.exports = React.createClass({
       }
     }
 
+    var optionalTextProps = textTransform ? {
+      transform: textTransform
+    } : {};
+
     return (
     <g>
       {ticks.map( (tick, idx) => {
@@ -175,6 +207,7 @@ module.exports = React.createClass({
               dy={dy} x={x1} y={y1}
               style={{stroke:props.tickTextStroke, fill:props.tickTextStroke}}
               textAnchor={textAnchor}
+              {...optionalTextProps}
             >
               {tickFormat(tick)}
             </text>

--- a/src/common/axes/Label.jsx
+++ b/src/common/axes/Label.jsx
@@ -30,59 +30,36 @@ module.exports = React.createClass({
 
     var props = this.props;
 
-    if (props.label) {
-      switch (props.orient) {
-        case 'top':
-          return (
-            <text
-              strokeWidth={props.strokeWidth.toString()}
-              textAnchor={props.textAnchor}
-              transform={props.verticalTransform}
-              x={props.width / 2}
-              y={props.offset}
-            >
-              {props.label}
-            </text>
-          );
-        case 'bottom':
-          return (
-            <text
-              strokeWidth={props.strokeWidth.toString()}
-              textAnchor={props.textAnchor}
-              transform={props.verticalTransform}
-              x={props.width / 2}
-              y={props.offset}
-            >
-              {props.label}
-            </text>
-          );
-        case 'left':
-          return (
-            <text
-              strokeWidth={props.strokeWidth.toString()}
-              textAnchor={props.textAnchor}
-              transform={props.horizontalTransform}
-              y={-props.offset}
-              x={-props.height / 2}
-            >
-              {props.label}
-            </text>
-          );
-        case 'right':
-          return (
-            <text
-              strokeWidth={props.strokeWidth.toString()}
-              textAnchor={props.textAnchor}
-              transform={props.horizontalTransform}
-              y={props.offset}
-              x={-props.height / 2}
-            >
-              {props.label}
-            </text>
-          );
+    if (!props.label) {
+      return <text/>;
+    }
+
+    var transform, x, y;
+    if (props.orient === 'top' || props.orient === 'bottom') {
+      transform = props.verticalTransform;
+      x = props.width / 2;
+      y = props.offset;
+    } else {  // left, right
+      transform = props.horizontalTransform;
+      x = -props.height / 2; 
+      if (props.orient === 'left') {
+        y = -props.offset;
+      } else {
+        y = props.offset;
       }
     }
-    return <text/>;
+
+    return (
+      <text
+        strokeWidth={props.strokeWidth.toString()}
+        textAnchor={props.textAnchor}
+        transform={transform}
+        y={y}
+        x={x}
+      >
+        {props.label}
+      </text>
+    );
   }
 
 });

--- a/src/common/axes/Label.jsx
+++ b/src/common/axes/Label.jsx
@@ -9,6 +9,7 @@ module.exports = React.createClass({
 
   propTypes: {
     height:              React.PropTypes.number,
+    horizontalChart:     React.PropTypes.bool,
     horizontalTransform: React.PropTypes.string,
     label:               React.PropTypes.string.isRequired,
     width:               React.PropTypes.number,
@@ -39,6 +40,10 @@ module.exports = React.createClass({
       transform = props.verticalTransform;
       x = props.width / 2;
       y = props.offset;
+
+      if (props.horizontalChart) {
+        transform = `rotate(180 ${x} ${y}) ${transform}`;
+      }
     } else {  // left, right
       transform = props.horizontalTransform;
       x = -props.height / 2; 
@@ -48,6 +53,7 @@ module.exports = React.createClass({
         y = props.offset;
       }
     }
+
 
     return (
       <text

--- a/src/common/axes/XAxis.jsx
+++ b/src/common/axes/XAxis.jsx
@@ -14,6 +14,7 @@ module.exports = React.createClass({
     fill:            React.PropTypes.string,
     height:          React.PropTypes.number.isRequired,
     width:           React.PropTypes.number.isRequired,
+    horizontalChart: React.PropTypes.bool,
     stroke:          React.PropTypes.string,
     strokeWidth:     React.PropTypes.string,
     tickStroke:      React.PropTypes.string,
@@ -76,6 +77,7 @@ module.exports = React.createClass({
           orient2nd={props.yOrient}
           height={props.height}
           width={props.width}
+          horizontalChart={props.horizontalChart}
           gridVertical={props.gridVertical}
           gridVerticalStroke={props.gridVerticalStroke}
           gridVerticalStrokeWidth={props.gridVerticalStrokeWidth}
@@ -89,6 +91,7 @@ module.exports = React.createClass({
           {...props}
         />
         <Label
+          horizontalChart={props.horizontalChart}
           label={props.xAxisLabel}
           offset={props.xAxisLabelOffset}
           orient={props.xOrient}

--- a/src/common/axes/YAxis.jsx
+++ b/src/common/axes/YAxis.jsx
@@ -17,6 +17,7 @@ module.exports = React.createClass({
     tickStroke:      React.PropTypes.string,
     width:           React.PropTypes.number.isRequired,
     height:          React.PropTypes.number.isRequired,
+    horizontalChart: React.PropTypes.bool,
     yAxisClassName:  React.PropTypes.string,
     yAxisLabel:      React.PropTypes.string,
     yAxisOffset:     React.PropTypes.number,
@@ -81,6 +82,7 @@ module.exports = React.createClass({
           scale={props.yScale}
           height={props.height}
           width={props.width}
+          horizontalChart={props.horizontalChart}
           gridHorizontal={props.gridHorizontal}
           gridHorizontalStroke={props.gridHorizontalStroke}
           gridHorizontalStrokeWidth={props.gridHorizontalStrokeWidth}
@@ -95,6 +97,7 @@ module.exports = React.createClass({
         />
         <Label
           height={props.height}
+          horizontalChart={props.horizontalChart}
           label={props.yAxisLabel}
           margins={props.margins}
           offset={props.yAxisLabelOffset}

--- a/src/linechart/LineChart.jsx
+++ b/src/linechart/LineChart.jsx
@@ -5,11 +5,11 @@ var d3 = require('d3');
 var { Chart, XAxis, YAxis } = require('../common');
 var DataSeries = require('./DataSeries');
 var utils = require('../utils');
-var { CartesianChartPropsMixin, ViewBoxMixin } = require('../mixins');
+var { CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin } = require('../mixins');
 
 module.exports = React.createClass({
 
-  mixins: [ CartesianChartPropsMixin, ViewBoxMixin ],
+  mixins: [ CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin ],
 
   displayName: 'LineChart',
 
@@ -40,7 +40,8 @@ module.exports = React.createClass({
       return null;
     }
 
-    var {innerWidth, innerHeight, trans} = this.getDimensions();
+    var {innerWidth, innerHeight, trans, svgMargins} = this.getDimensions();
+    var yOrient = this.getYOrient();
 
     if (!Array.isArray(props.data)) {
       props.data = [props.data];
@@ -78,11 +79,12 @@ module.exports = React.createClass({
             xAxisLabelOffset={props.xAxisLabelOffset}
             tickFormatting={props.xAxisFormatter}
             xOrient={props.xOrient}
-            yOrient={props.yOrient}
+            yOrient={yOrient}
             data={props.data}
-            margins={props.margins}
+            margins={svgMargins}
             width={innerWidth}
             height={innerHeight}
+            horizontalChart={props.horizontal}
             stroke={props.axesColor}
             gridVertical={props.gridVertical}
             gridVerticalStroke={props.gridVerticalStroke}
@@ -100,10 +102,11 @@ module.exports = React.createClass({
             yAxisLabelOffset={props.yAxisLabelOffset}
             tickFormatting={props.yAxisFormatter}
             xOrient={props.xOrient}
-            yOrient={props.yOrient}
-            margins={props.margins}
+            yOrient={yOrient}
+            margins={svgMargins}
             width={innerWidth}
             height={innerHeight}
+            horizontalChart={props.horizontal}
             stroke={props.axesColor}
             gridHorizontal={props.gridHorizontal}
             gridHorizontalStroke={props.gridHorizontalStroke}

--- a/src/linechart/LineChart.jsx
+++ b/src/linechart/LineChart.jsx
@@ -40,7 +40,7 @@ module.exports = React.createClass({
       return null;
     }
 
-    var {innerWidth, innerHeight} = this.getDimensions();
+    var {innerWidth, innerHeight, trans} = this.getDimensions();
 
     if (!Array.isArray(props.data)) {
       props.data = [props.data];
@@ -53,7 +53,6 @@ module.exports = React.createClass({
         xValues = flattenedData.xValues,
         yValues = flattenedData.yValues;
     var scales = this._calculateScales(innerWidth, innerHeight, xValues, yValues);
-    var trans = "translate(" + (props.yAxisOffset < 0 ? props.margins.left + Math.abs(props.yAxisOffset) : props.margins.left) + "," + props.margins.top + ")";
 
     return (
       <Chart
@@ -65,7 +64,8 @@ module.exports = React.createClass({
         colorAccessor={props.colorAccessor}
         width={props.width}
         height={props.height}
-        title={props.title}>
+        title={props.title}
+      >
         <g transform={trans} className={props.className}>
           <XAxis
             xAxisClassName={props.xAxisClassName}

--- a/src/linechart/LineChart.jsx
+++ b/src/linechart/LineChart.jsx
@@ -40,11 +40,7 @@ module.exports = React.createClass({
       return null;
     }
 
-    // Calculate inner chart dimensions
-    var innerWidth, innerHeight;
-
-    innerWidth = this.getOuterDimensions().width - props.margins.left - props.margins.right;
-    innerHeight = this.getOuterDimensions().height - props.margins.top - props.margins.bottom;
+    var {innerWidth, innerHeight} = this.getDimensions();
 
     if (!Array.isArray(props.data)) {
       props.data = [props.data];

--- a/src/mixins/CartesianChartPropsMixin.js
+++ b/src/mixins/CartesianChartPropsMixin.js
@@ -11,6 +11,7 @@ module.exports =  {
     colorAccessor:     React.PropTypes.func,
     data:              React.PropTypes.array.isRequired,
     height:            React.PropTypes.number,
+    horizontal:        React.PropTypes.bool,
     legend:            React.PropTypes.bool,
     legendOffset:      React.PropTypes.number,
     title:             React.PropTypes.string,
@@ -32,7 +33,7 @@ module.exports =  {
     yAxisTickInterval: React.PropTypes.object,
     yAxisTickValues:   React.PropTypes.array,
     yAxisOffset:       React.PropTypes.number,
-    yOrient:           React.PropTypes.oneOf(['left', 'right'])
+    yOrient:           React.PropTypes.oneOf(['default', 'left', 'right'])
   },
 
   getDefaultProps: function() {
@@ -41,11 +42,11 @@ module.exports =  {
       colors:           d3.scale.category20c(),
       colorAccessor:    (d, idx) => idx,
       height:           200,
+      horizontal:       false,
       legend:           false,
       legendOffset:     120,
       title:            '',
       width:            400,
-      xAccessor:        (d) => d.x,
       // xAxisFormatter: no predefined value right now
       xAxisLabel:       '',
       xAxisLabelOffset: 38,
@@ -54,7 +55,6 @@ module.exports =  {
       // xAxisTickInterval: no predefined value right now
       // xAxisTickValues: no predefined value right now
       xOrient:          'bottom',
-      yAccessor:        (d) => d.y,
       // yAxisFormatter: no predefined value right now
       yAxisLabel:       '',
       yAxisLabelOffset: 35,
@@ -62,7 +62,17 @@ module.exports =  {
       // yAxisTickCount: no predefined value right now
       // yAxisTickInterval: no predefined value right now
       // yAxisTickValues: no predefined value right now
-      yOrient:          'left'
+      yOrient:          'default'
     };
+  },
+
+  getYOrient() {
+    var yOrient = this.props.yOrient;
+
+    if (yOrient === 'default') {
+      return this.props.horizontal ? 'right' : 'left'; 
+    }
+
+    return yOrient;
   }
 };

--- a/src/mixins/CartesianChartPropsMixin.js
+++ b/src/mixins/CartesianChartPropsMixin.js
@@ -22,6 +22,7 @@ module.exports =  {
     xAxisTickCount:    React.PropTypes.number,
     xAxisTickInterval: React.PropTypes.object,
     xAxisTickValues:   React.PropTypes.array,
+    xAxisOffset:       React.PropTypes.number,
     xOrient:           React.PropTypes.oneOf(['top', 'bottom']),
     yAccessor:         React.PropTypes.func,
     yAxisFormatter:    React.PropTypes.func,
@@ -30,6 +31,7 @@ module.exports =  {
     yAxisTickCount:    React.PropTypes.number,
     yAxisTickInterval: React.PropTypes.object,
     yAxisTickValues:   React.PropTypes.array,
+    yAxisOffset:       React.PropTypes.number,
     yOrient:           React.PropTypes.oneOf(['left', 'right'])
   },
 
@@ -47,6 +49,7 @@ module.exports =  {
       // xAxisFormatter: no predefined value right now
       xAxisLabel:       '',
       xAxisLabelOffset: 38,
+      xAxisOffset:      0,
       // xAxisTickCount: no predefined value right now
       // xAxisTickInterval: no predefined value right now
       // xAxisTickValues: no predefined value right now
@@ -55,6 +58,7 @@ module.exports =  {
       // yAxisFormatter: no predefined value right now
       yAxisLabel:       '',
       yAxisLabelOffset: 35,
+      yAxisOffset:      0,
       // yAxisTickCount: no predefined value right now
       // yAxisTickInterval: no predefined value right now
       // yAxisTickValues: no predefined value right now

--- a/src/mixins/DefaultAccessorsMixin.js
+++ b/src/mixins/DefaultAccessorsMixin.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var React = require('react');
+
+module.exports = {
+  propTypes: {
+    xAccessor: React.PropTypes.func,
+    yAccessor: React.PropTypes.func
+  },
+
+  getDefaultProps() {
+    return {
+      xAccessor: (d) => d.x,
+      yAccessor: (d) => d.y
+    };
+  }
+}

--- a/src/mixins/ViewBoxMixin.js
+++ b/src/mixins/ViewBoxMixin.js
@@ -21,10 +21,10 @@ module.exports =  {
 
   getDimensions() {
     var props = this.props;
-    var {margins, viewBoxObject, yAxisOffset} = props;
-    var width;
-    var height;
-    
+    var {horizontal, margins, viewBoxObject, xOrient, xAxisOffset, yAxisOffset} = props;
+    var yOrient = this.getYOrient();
+
+    var width, height;
     if (viewBoxObject) {
       width = viewBoxObject.width,
       height = viewBoxObject.height
@@ -33,12 +33,40 @@ module.exports =  {
       height = props.height
     }
 
+    var svgWidth, svgHeight;
+    var xOffset, yOffset;
+    var svgMargins;
+    var trans;
+    if (horizontal) {
+      var center = width / 2;
+      trans = `rotate(90 ${ center } ${ center }) `;
+      svgWidth = height;
+      svgHeight = width;
+      svgMargins = {
+        left: margins.top,
+        top: margins.right,
+        right: margins.bottom,
+        bottom: margins.left
+      };
+    } else {
+      trans = '';
+      svgWidth = width;
+      svgHeight = height;
+      svgMargins = margins;
+    }
+
+    var xAxisOffset = Math.abs(props.xAxisOffset || 0);
+    var yAxisOffset = Math.abs(props.yAxisOffset || 0);
+
+    var xOffset = svgMargins.left + (yOrient === 'left' ? yAxisOffset : 0);
+    var yOffset = svgMargins.top + (xOrient === 'top' ? xAxisOffset : 0);
+    trans += `translate(${ xOffset }, ${ yOffset })`;
+
     return {
-      width: width,
-      height: height,
-      innerWidth: width - margins.left - margins.right,
-      innerHeight: height - margins.top - margins.bottom,
-      trans: `translate(${ yAxisOffset < 0 ? margins.left + Math.abs(yAxisOffset) : margins.left},${ margins.top })`
+      innerHeight: svgHeight - svgMargins.top - svgMargins.bottom - xAxisOffset,
+      innerWidth: svgWidth - svgMargins.left - svgMargins.right - yAxisOffset,
+      trans: trans,
+      svgMargins: svgMargins
     };
   }
 

--- a/src/mixins/ViewBoxMixin.js
+++ b/src/mixins/ViewBoxMixin.js
@@ -21,7 +21,7 @@ module.exports =  {
 
   getDimensions() {
     var props = this.props;
-    var {margins, viewBoxObject} = props;
+    var {margins, viewBoxObject, yAxisOffset} = props;
     var width;
     var height;
     
@@ -37,7 +37,8 @@ module.exports =  {
       width: width,
       height: height,
       innerWidth: width - margins.left - margins.right,
-      innerHeight: height - margins.top - margins.bottom
+      innerHeight: height - margins.top - margins.bottom,
+      trans: `translate(${ yAxisOffset < 0 ? margins.left + Math.abs(yAxisOffset) : margins.left},${ margins.top })`
     };
   }
 

--- a/src/mixins/ViewBoxMixin.js
+++ b/src/mixins/ViewBoxMixin.js
@@ -19,18 +19,26 @@ module.exports =  {
     } 
   },
 
-  getOuterDimensions() {
-    if (this.props.viewBoxObject) {
-      return {
-        width: this.props.viewBoxObject.width,
-        height: this.props.viewBoxObject.height
-      };
+  getDimensions() {
+    var props = this.props;
+    var {margins, viewBoxObject} = props;
+    var width;
+    var height;
+    
+    if (viewBoxObject) {
+      width = viewBoxObject.width,
+      height = viewBoxObject.height
     } else {
-      return {
-        width: this.props.width,
-        height: this.props.height
-      };
+      width = props.width,
+      height = props.height
     }
+
+    return {
+      width: width,
+      height: height,
+      innerWidth: width - margins.left - margins.right,
+      innerHeight: height - margins.top - margins.bottom
+    };
   }
 
 };

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -1,3 +1,4 @@
 
 exports.CartesianChartPropsMixin = require('./CartesianChartPropsMixin');
+exports.DefaultAccessorsMixin = require('./DefaultAccessorsMixin');
 exports.ViewBoxMixin = require('./ViewBoxMixin');

--- a/src/scatterchart/ScatterChart.jsx
+++ b/src/scatterchart/ScatterChart.jsx
@@ -49,7 +49,7 @@ module.exports = React.createClass({
       return null;
     }
 
-    var {innerWidth, innerHeight} = this.getDimensions();
+    var {innerWidth, innerHeight, trans} = this.getDimensions();
 
     // Returns an object of flattened allValues, xValues, and yValues
     var flattenedData = utils.flattenData(data, props.xAccessor, props.yAccessor);
@@ -61,9 +61,6 @@ module.exports = React.createClass({
     var scales  = this._calculateScales(innerWidth, innerHeight, xValues, yValues);
     var xScale  = scales.xScale;
     var yScale  = scales.yScale;
-
-    var x = props.yAxisOffset < 0 ? (margins.left + Math.abs(props.yAxisOffset)) : margins.left;
-    var transform = `translate(${x}, ${margins.top})`;
 
     return (
       <Chart
@@ -79,7 +76,7 @@ module.exports = React.createClass({
       >
         <g
           className={props.className}
-          transform={transform}
+          transform={trans}
         >
           <XAxis
             data={data}

--- a/src/scatterchart/ScatterChart.jsx
+++ b/src/scatterchart/ScatterChart.jsx
@@ -49,9 +49,7 @@ module.exports = React.createClass({
       return null;
     }
 
-    // Calculate inner chart dimensions
-    var innerWidth  = this.getOuterDimensions().width - margins.left - margins.right;
-    var innerHeight = this.getOuterDimensions().height - margins.top - margins.bottom;
+    var {innerWidth, innerHeight} = this.getDimensions();
 
     // Returns an object of flattened allValues, xValues, and yValues
     var flattenedData = utils.flattenData(data, props.xAccessor, props.yAccessor);

--- a/src/scatterchart/ScatterChart.jsx
+++ b/src/scatterchart/ScatterChart.jsx
@@ -5,11 +5,11 @@ var d3 = require('d3');
 var { Chart, XAxis, YAxis } = require('../common');
 var DataSeries = require('./DataSeries');
 var utils = require('../utils');
-var { CartesianChartPropsMixin, ViewBoxMixin } = require('../mixins');
+var { CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin } = require('../mixins');
 
 module.exports = React.createClass({
 
-  mixins: [ CartesianChartPropsMixin, ViewBoxMixin ],
+  mixins: [ CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin ],
 
   displayName: 'ScatterChart',
 
@@ -43,13 +43,13 @@ module.exports = React.createClass({
 
     var props = this.props;
     var data  = props.data;
-    var margins = props.margins;
 
     if (!data || data.length < 1) {
       return null;
     }
 
-    var {innerWidth, innerHeight, trans} = this.getDimensions();
+    var {innerWidth, innerHeight, trans, svgMargins} = this.getDimensions();
+    var yOrient = this.getYOrient();
 
     // Returns an object of flattened allValues, xValues, and yValues
     var flattenedData = utils.flattenData(data, props.xAccessor, props.yAccessor);
@@ -69,7 +69,7 @@ module.exports = React.createClass({
         data={data}
         height={props.height}
         legend={props.legend}
-        margins={margins}
+        margins={props.margins}
         title={props.title}
         viewBox={this.getViewBox()}
         width={props.width}
@@ -81,7 +81,8 @@ module.exports = React.createClass({
           <XAxis
             data={data}
             height={innerHeight}
-            margins={margins}
+            horizontalChart={props.horizontal}
+            margins={svgMargins}
             stroke={props.axesColor}
             strokeWidth={props.xAxisStrokeWidth.toString()}
             tickFormatting={props.xAxisFormatter}
@@ -93,7 +94,7 @@ module.exports = React.createClass({
             xAxisTickInterval={props.xAxisTickInterval}
             xAxisTickValues={props.xAxisTickValues}
             xOrient={props.xOrient}
-            yOrient={props.yOrient}
+            yOrient={yOrient}
             xScale={xScale}
             gridVertical={props.gridVertical}
             gridVerticalStroke={props.gridVerticalStroke}
@@ -104,7 +105,8 @@ module.exports = React.createClass({
             data={data}
             width={innerWidth}
             height={innerHeight}
-            margins={margins}
+            horizontalChart={props.horizontal}
+            margins={svgMargins}
             stroke={props.axesColor}
             strokeWidth={props.yAxisStrokeWidth.toString()}
             tickFormatting={props.yAxisFormatter}
@@ -116,7 +118,7 @@ module.exports = React.createClass({
             yAxisTickCount={props.yAxisTickCount}
             yScale={yScale}
             xOrient={props.xOrient}
-            yOrient={props.yOrient}
+            yOrient={yOrient}
             gridHorizontal={props.gridHorizontal}
             gridHorizontalStroke={props.gridHorizontalStroke}
             gridHorizontalStrokeWidth={props.gridHorizontalStrokeWidth}

--- a/tests/barchart-tests.js
+++ b/tests/barchart-tests.js
@@ -30,7 +30,7 @@ describe('BarChart', function() {
     var barchartGroup = TestUtils.findRenderedDOMComponentWithClass(
       barchart, 'rd3-barchart');
     expect(barchartGroup).to.exist;
-    expect(barchartGroup.tagName).to.equal('G');
+    expect(barchartGroup.tagName).to.equal('g');
 
     // Verify that it has the same number of bars as the array's length
     var bars = TestUtils.scryRenderedDOMComponentsWithTag(
@@ -69,7 +69,7 @@ describe('BarChart', function() {
     var barchartGroup = TestUtils.findRenderedDOMComponentWithClass(
       barchart, 'rd3-barchart');
     expect(barchartGroup).to.exist;
-    expect(barchartGroup.tagName).to.equal('G');
+    expect(barchartGroup.tagName).to.equal('g');
 
     // Verify that it has the same number of bars as the array's length
     var bars = TestUtils.scryRenderedDOMComponentsWithTag(

--- a/tests/candlestick-tests.js
+++ b/tests/candlestick-tests.js
@@ -55,7 +55,7 @@ describe('CandlestickChart', function() {
     var candlestickGroup = TestUtils.findRenderedDOMComponentWithClass(
       candlestickChart, 'rd3-candlestick');
     expect(candlestickGroup).to.exist;
-    expect(candlestickGroup.tagName).to.equal('G');
+    expect(candlestickGroup.tagName).to.equal('g');
   });
 
   it('renders same amount of wicks and candles with data', function() {
@@ -97,7 +97,7 @@ describe('CandlestickChart', function() {
     var candlestickGroup = TestUtils.findRenderedDOMComponentWithClass(
       candlestickChartWithoutAnimation, CHART_WO_ANIMATION_CLASS_NAME);
     expect(candlestickGroup).to.exist;
-    expect(candlestickGroup.tagName).to.equal('G');
+    expect(candlestickGroup.tagName).to.equal('g');
   });
 
   it('candle does not animate since hoverAnimation is set to false', function() {

--- a/tests/piechart-tests.js
+++ b/tests/piechart-tests.js
@@ -21,7 +21,7 @@ describe('PieChart', function() {
     var pie = TestUtils.findRenderedDOMComponentWithClass(
       piechart, 'rd3-piechart');
     expect(pie).to.exist;
-    expect(pie.tagName).to.equal('G');
+    expect(pie.tagName).to.equal('g');
 
     var pieGroup = TestUtils.findRenderedDOMComponentWithClass(piechart, 'rd3-piechart-pie');
     expect(pieGroup).to.exist;

--- a/tests/scatterchart-tests.js
+++ b/tests/scatterchart-tests.js
@@ -43,7 +43,7 @@ describe('ScatterChart', function() {
     var scatterchartGroup = TestUtils.findRenderedDOMComponentWithClass(
       scatterchart, CHART_CLASS_NAME);
     expect(scatterchartGroup).to.exist;
-    expect(scatterchartGroup.tagName).to.equal('G');
+    expect(scatterchartGroup.tagName).to.equal('g');
 
   });
 

--- a/tests/treemap-tests.js
+++ b/tests/treemap-tests.js
@@ -20,7 +20,7 @@ describe('Treemap', function() {
 
     var treemapGroup = TestUtils.findRenderedDOMComponentWithClass(treemap, 'rd3-treemap');
     expect(treemapGroup).to.exist;
-    expect(treemapGroup.tagName).to.equal('G');
+    expect(treemapGroup.tagName).to.equal('g');
     
     // Verify that it has the same number of nodes as the array's length
     var cells = TestUtils.scryRenderedDOMComponentsWithClass(treemap, 'rd3-treemap-cell');

--- a/tests/treemap-tests.js
+++ b/tests/treemap-tests.js
@@ -6,7 +6,7 @@ describe('Treemap', function() {
   it('renders treemap', function() {
     var React = require('react/addons');
     var Treemap = require('../src/treemap').Treemap;
-    var generate = require('./utils/datagen').generateArrayOfNumbers;
+    var generate = require('./utils/datagen').generateArrayOfNameObjects;
     var TestUtils = React.addons.TestUtils;
     var points = 5;
 
@@ -24,12 +24,12 @@ describe('Treemap', function() {
     
     // Verify that it has the same number of nodes as the array's length
     var cells = TestUtils.scryRenderedDOMComponentsWithClass(treemap, 'rd3-treemap-cell');
+    // Magic number '1' is the parent node
+    expect(cells.length).to.equal(data.length + 1);
 
     // Note that the first node generated will always be the parent node 
     expect(Number(cells[0].getDOMNode().getAttribute('width'))).to.equal(width);
 
-    // Magic number '1' is the parent node
-    expect(cells.length).to.equal(data.length + 1);
 
     var labels = TestUtils.scryRenderedDOMComponentsWithClass(
       treemap, 'rd3-treemap-cell-text');

--- a/tests/utils/datagen.js
+++ b/tests/utils/datagen.js
@@ -28,7 +28,7 @@ exports.generateArrayOfNameObjects = function(n) {
     var j = Math.floor(Math.random() * 100);
     numbers.push(j);
   } 
-  var data = new Array(n);
+  var data = [];
   numbers.forEach( function(value, idx) {
     var i = idx % 10;
     var name = names[i];


### PR DESCRIPTION
Some description of the implementation here: https://github.com/esbullington/react-d3/commit/abdd34fa00bc652b37b4be720ac99523c481c555

Feedback welcome.

There are no tests, I suppose it wouldn't be hard to test the rotation and translation behavior of axis and tick labels, but at least this is open to review now.

**In the images below, the less-than-ideal axis label placements and the candlestick bottom axis overlap issue are due to the fact that these screenshots are of the example page with no properties modified other than horizontal={true}.**  When adjusting `margins` and (for candlestick) `yAxisOffset` to better values for horizontal charts, they look better.  To implement two different default margins depending on orientation would be additional work.

<img width="503" alt="screen shot 2015-11-13 at 3 45 48 pm" src="https://cloud.githubusercontent.com/assets/344026/11159146/55e691ea-8a2b-11e5-998c-4c6a272b69df.png">
<img width="499" alt="screen shot 2015-11-13 at 3 46 04 pm" src="https://cloud.githubusercontent.com/assets/344026/11159143/55e447d2-8a2b-11e5-9f70-39c9238a02e8.png">
<img width="528" alt="screen shot 2015-11-13 at 3 46 11 pm" src="https://cloud.githubusercontent.com/assets/344026/11159147/55e818b2-8a2b-11e5-82ea-4e7b5c659ec7.png">
<img width="503" alt="screen shot 2015-11-13 at 3 46 17 pm" src="https://cloud.githubusercontent.com/assets/344026/11159145/55e4bd34-8a2b-11e5-951c-c411f6eef79a.png">
<img width="555" alt="screen shot 2015-11-13 at 3 46 24 pm" src="https://cloud.githubusercontent.com/assets/344026/11159144/55e4a8da-8a2b-11e5-9c64-30503efbea22.png">
