### PR TITLE
Tooltips for line, scatter, bar and pie charts

### DIFF
--- a/src/barchart/BarChart.jsx
+++ b/src/barchart/BarChart.jsx
@@ -5,12 +5,12 @@ var d3 = require('d3');
 var DataSeries = require('./DataSeries');
 var utils = require('../utils');
 
-var { Chart, XAxis, YAxis } = require('../common');
-var { CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin } = require('../mixins');
+var { Chart, XAxis, YAxis, Tooltip } = require('../common');
+var { CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin, TooltipMixin } = require('../mixins');
 
 module.exports = React.createClass({
 
-  mixins: [ CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin ],
+  mixins: [ CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin, TooltipMixin ],
 
   displayName: 'BarChart',
 
@@ -90,69 +90,74 @@ module.exports = React.createClass({
       .domain([0, this._getStackedValuesMaxY(_data)]);
 
     return (
-      <Chart
-        viewBox={this.getViewBox()}
-        legend={props.legend}
-        data={props.data}
-        margins={props.margins}
-        colors={props.colors}
-        colorAccessor={props.colorAccessor}
-        width={props.width}
-        height={props.height}
-        title={props.title}
-      >
-        <g transform={trans} className={props.chartClassName}>
-          <YAxis
-            yAxisClassName={props.yAxisClassName}
-            yAxisTickValues={props.yAxisTickValues}
-            yAxisLabel={props.yAxisLabel}
-            yAxisLabelOffset={props.yAxisLabelOffset}
-            yScale={yScale}
-            margins={svgMargins}
-            yAxisTickCount={props.yAxisTickCount}
-            tickFormatting={props.yAxisFormatter}
-            width={innerWidth}
-            height={innerHeight}
-            horizontalChart={props.horizontal}
-            xOrient={props.xOrient}
-            yOrient={yOrient}
-            gridHorizontal={props.gridHorizontal}
-            gridHorizontalStroke={props.gridHorizontalStroke}
-            gridHorizontalStrokeWidth={props.gridHorizontalStrokeWidth}
-            gridHorizontalStrokeDash={props.gridHorizontalStrokeDash}
-          />
-          <XAxis
-            xAxisClassName={props.xAxisClassName}
-            xAxisTickValues={props.xAxisTickValues}
-            xAxisLabel={props.xAxisLabel}
-            xAxisLabelOffset={props.xAxisLabelOffset} 
-            xScale={xScale}
-            margins={svgMargins}
-            tickFormatting={props.xAxisFormatter}
-            width={innerWidth}
-            height={innerHeight}
-            horizontalChart={props.horizontal}
-            xOrient={props.xOrient}
-            yOrient={yOrient}
-            gridVertical={props.gridVertical}
-            gridVerticalStroke={props.gridVerticalStroke}
-            gridVerticalStrokeWidth={props.gridVerticalStrokeWidth}
-            gridVerticalStrokeDash={props.gridVerticalStrokeDash}
-          />
-          <DataSeries
-            yScale={yScale}
-            xScale={xScale}
-            margins={svgMargins}
-            _data={_data}
-            width={innerWidth}
-            height={innerHeight}
-            colors={props.colors}
-            colorAccessor={props.colorAccessor}
-            hoverAnimation={props.hoverAnimation}
-            valuesAccessor={props.valuesAccessor}
+      <span>
+        <Chart
+          viewBox={this.getViewBox()}
+          legend={props.legend}
+          data={props.data}
+          margins={props.margins}
+          colors={props.colors}
+          colorAccessor={props.colorAccessor}
+          width={props.width}
+          height={props.height}
+          title={props.title}
+        >
+          <g transform={trans} className={props.chartClassName}>
+            <YAxis
+              yAxisClassName={props.yAxisClassName}
+              yAxisTickValues={props.yAxisTickValues}
+              yAxisLabel={props.yAxisLabel}
+              yAxisLabelOffset={props.yAxisLabelOffset}
+              yScale={yScale}
+              margins={svgMargins}
+              yAxisTickCount={props.yAxisTickCount}
+              tickFormatting={props.yAxisFormatter}
+              width={innerWidth}
+              height={innerHeight}
+              horizontalChart={props.horizontal}
+              xOrient={props.xOrient}
+              yOrient={yOrient}
+              gridHorizontal={props.gridHorizontal}
+              gridHorizontalStroke={props.gridHorizontalStroke}
+              gridHorizontalStrokeWidth={props.gridHorizontalStrokeWidth}
+              gridHorizontalStrokeDash={props.gridHorizontalStrokeDash}
             />
-        </g>
-      </Chart>
+            <XAxis
+              xAxisClassName={props.xAxisClassName}
+              xAxisTickValues={props.xAxisTickValues}
+              xAxisLabel={props.xAxisLabel}
+              xAxisLabelOffset={props.xAxisLabelOffset} 
+              xScale={xScale}
+              margins={svgMargins}
+              tickFormatting={props.xAxisFormatter}
+              width={innerWidth}
+              height={innerHeight}
+              horizontalChart={props.horizontal}
+              xOrient={props.xOrient}
+              yOrient={yOrient}
+              gridVertical={props.gridVertical}
+              gridVerticalStroke={props.gridVerticalStroke}
+              gridVerticalStrokeWidth={props.gridVerticalStrokeWidth}
+              gridVerticalStrokeDash={props.gridVerticalStrokeDash}
+            />
+            <DataSeries
+              yScale={yScale}
+              xScale={xScale}
+              margins={svgMargins}
+              _data={_data}
+              width={innerWidth}
+              height={innerHeight}
+              colors={props.colors}
+              colorAccessor={props.colorAccessor}
+              hoverAnimation={props.hoverAnimation}
+              valuesAccessor={props.valuesAccessor}
+              onMouseOver={this.onMouseOver}
+              onMouseLeave={this.onMouseLeave}
+              />
+          </g>
+        </Chart>
+        {(props.showTooltip ? <Tooltip {...this.state.tooltip}/> : null)}
+      </span>
     );
   }
 

--- a/src/barchart/BarChart.jsx
+++ b/src/barchart/BarChart.jsx
@@ -89,6 +89,8 @@ module.exports = React.createClass({
       .range([innerHeight, 0])
       .domain([0, this._getStackedValuesMaxY(_data)]);
 
+    var series = props.data.map( (item) => item.name );
+
     return (
       <span>
         <Chart
@@ -145,6 +147,7 @@ module.exports = React.createClass({
               xScale={xScale}
               margins={svgMargins}
               _data={_data}
+              series={series}
               width={innerWidth}
               height={innerHeight}
               colors={props.colors}

--- a/src/barchart/BarContainer.jsx
+++ b/src/barchart/BarContainer.jsx
@@ -39,12 +39,15 @@ module.exports = React.createClass({
   },
 
   _animateBar() {
+    var rect = this.getDOMNode().getBoundingClientRect();
+    this.props.onMouseOver.call(this, rect.right, rect.top, this.props.dataPoint )
     this.setState({ 
       fill: shade(this.props.fill, 0.2)
     });
   },
 
   _restoreBar() {
+    this.props.onMouseLeave.call(this);
     this.setState({ 
       fill: this.props.fill
     });

--- a/src/barchart/DataSeries.jsx
+++ b/src/barchart/DataSeries.jsx
@@ -10,6 +10,7 @@ module.exports = React.createClass({
 
   propTypes: {
     _data:          React.PropTypes.array,
+    series:   React.PropTypes.array,
     colors:         React.PropTypes.func,
     colorAccessor:  React.PropTypes.func,
     height:         React.PropTypes.number,
@@ -43,7 +44,7 @@ module.exports = React.createClass({
         hoverAnimation={hoverAnimation}
         onMouseOver={this.props.onMouseOver}
         onMouseLeave={this.props.onMouseLeave}
-        dataPoint={{xValue: segment.x, yValue: segment.y}}
+        dataPoint={{xValue: segment.x, yValue: segment.y, seriesName: this.props.series[seriesIdx]}}
       />
     )
   }

--- a/src/barchart/DataSeries.jsx
+++ b/src/barchart/DataSeries.jsx
@@ -41,6 +41,9 @@ module.exports = React.createClass({
         y={yScale( segment.y0 + segment.y )}
         fill={colors(colorAccessor(segment, seriesIdx))}
         hoverAnimation={hoverAnimation}
+        onMouseOver={this.props.onMouseOver}
+        onMouseLeave={this.props.onMouseLeave}
+        dataPoint={{xValue: segment.x, yValue: segment.y}}
       />
     )
   }

--- a/src/common/Tooltip.jsx
+++ b/src/common/Tooltip.jsx
@@ -1,0 +1,37 @@
+'use strict';
+
+var React = require('react');
+
+module.exports = React.createClass({
+
+  propTypes: {
+    cx:   React.PropTypes.number,
+    cy:   React.PropTypes.number,
+    text: React.PropTypes.string,
+    show: React.PropTypes.bool
+  },
+
+  render: function() {
+    var props = this.props;
+    var display = this.props.show ? 'inherit' : 'none';
+    var containerStyles = {position: 'fixed', top: props.cy, left: props.cx, display: display, opacity: 0.8}
+    var tooltipStyles = {
+      position: 'absolute',
+      backgroundColor: 'white',
+      border: '1px solid',
+      borderColor: '#ddd',
+      borderRadius: '2px',
+      padding: '10px',
+      marginLeft: '10px',
+      marginRight: '10px',
+      marginTop: '-15px'
+    }
+    return (
+      <div style={containerStyles}>
+        <div style={tooltipStyles}>
+          {props.text}
+        </div>
+      </div>
+    );
+  }
+});

--- a/src/common/Tooltip.jsx
+++ b/src/common/Tooltip.jsx
@@ -15,6 +15,8 @@ module.exports = React.createClass({
     var props = this.props;
     var display = this.props.show ? 'inherit' : 'none';
     var containerStyles = {position: 'fixed', top: props.cy, left: props.cx, display: display, opacity: 0.8}
+    
+    //TODO: add 'right: 0px' style when tooltip is off the chart
     var tooltipStyles = {
       position: 'absolute',
       backgroundColor: 'white',

--- a/src/common/Tooltip.jsx
+++ b/src/common/Tooltip.jsx
@@ -7,7 +7,11 @@ module.exports = React.createClass({
   propTypes: {
     x:   React.PropTypes.number,
     y:   React.PropTypes.number,
-    text: React.PropTypes.string,
+    child: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.number,
+      React.PropTypes.element
+    ]),
     show: React.PropTypes.bool
   },
 
@@ -31,7 +35,7 @@ module.exports = React.createClass({
     return (
       <div style={containerStyles}>
         <div style={tooltipStyles}>
-          {props.text}
+          {props.child}
         </div>
       </div>
     );

--- a/src/common/Tooltip.jsx
+++ b/src/common/Tooltip.jsx
@@ -5,8 +5,8 @@ var React = require('react');
 module.exports = React.createClass({
 
   propTypes: {
-    cx:   React.PropTypes.number,
-    cy:   React.PropTypes.number,
+    x:   React.PropTypes.number,
+    y:   React.PropTypes.number,
     text: React.PropTypes.string,
     show: React.PropTypes.bool
   },
@@ -14,7 +14,7 @@ module.exports = React.createClass({
   render: function() {
     var props = this.props;
     var display = this.props.show ? 'inherit' : 'none';
-    var containerStyles = {position: 'fixed', top: props.cy, left: props.cx, display: display, opacity: 0.8}
+    var containerStyles = {position: 'fixed', top: props.y, left: props.x, display: display, opacity: 0.8}
     
     //TODO: add 'right: 0px' style when tooltip is off the chart
     var tooltipStyles = {

--- a/src/common/index.js
+++ b/src/common/index.js
@@ -4,4 +4,5 @@ exports.YAxis = require('./axes').YAxis;
 exports.Chart = require('./charts').Chart;
 exports.LegendChart = require('./charts').LegendChart;
 exports.Legend = require('./Legend');
+exports.Tooltip = require('./Tooltip');
 exports.Voronoi = require('./Voronoi');

--- a/src/linechart/DataSeries.jsx
+++ b/src/linechart/DataSeries.jsx
@@ -95,6 +95,8 @@ module.exports = React.createClass({
               hoverAnimation={props.hoverAnimation}
               cx={cx} cy={cy} 
               circleRadius={props.circleRadius}
+              onMouseOver={props.onMouseOver}
+              dataPoint={{xValue: xAccessor(point), yValue: yAccessor(point)}}
           />
       );
     }.bind(this));

--- a/src/linechart/DataSeries.jsx
+++ b/src/linechart/DataSeries.jsx
@@ -96,7 +96,7 @@ module.exports = React.createClass({
               cx={cx} cy={cy} 
               circleRadius={props.circleRadius}
               onMouseOver={props.onMouseOver}
-              dataPoint={{xValue: xAccessor(point), yValue: yAccessor(point)}}
+              dataPoint={{xValue: xAccessor(point), yValue: yAccessor(point), seriesName: vnode.point.series.name}}
           />
       );
     }.bind(this));

--- a/src/linechart/LineChart.jsx
+++ b/src/linechart/LineChart.jsx
@@ -2,14 +2,14 @@
 
 var React = require('react');
 var d3 = require('d3');
-var { Chart, XAxis, YAxis } = require('../common');
+var { Chart, XAxis, YAxis, Tooltip} = require('../common');
 var DataSeries = require('./DataSeries');
 var utils = require('../utils');
-var { CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin } = require('../mixins');
+var { CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin, TooltipMixin } = require('../mixins');
 
 module.exports = React.createClass({
 
-  mixins: [ CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin ],
+  mixins: [ CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin, TooltipMixin ],
 
   displayName: 'LineChart',
 
@@ -17,7 +17,7 @@ module.exports = React.createClass({
     circleRadius:   React.PropTypes.number,
     hoverAnimation: React.PropTypes.bool,
     margins:        React.PropTypes.object,
- },
+  },
 
   getDefaultProps() {
     return {
@@ -56,80 +56,84 @@ module.exports = React.createClass({
     var scales = this._calculateScales(innerWidth, innerHeight, xValues, yValues);
 
     return (
-      <Chart
-        viewBox={this.getViewBox()}
-        legend={props.legend}
-        data={props.data}
-        margins={props.margins}
-        colors={props.colors}
-        colorAccessor={props.colorAccessor}
-        width={props.width}
-        height={props.height}
-        title={props.title}
-      >
-        <g transform={trans} className={props.className}>
-          <XAxis
-            xAxisClassName={props.xAxisClassName}
-            strokeWidth={props.xAxisStrokeWidth}
-            xAxisTickValues={props.xAxisTickValues}
-            xAxisTickInterval={props.xAxisTickInterval}
-            xAxisOffset={props.xAxisOffset}
-            xScale={scales.xScale}
-            xAxisLabel={props.xAxisLabel}
-            xAxisLabelOffset={props.xAxisLabelOffset}
-            tickFormatting={props.xAxisFormatter}
-            xOrient={props.xOrient}
-            yOrient={yOrient}
-            data={props.data}
-            margins={svgMargins}
-            width={innerWidth}
-            height={innerHeight}
-            horizontalChart={props.horizontal}
-            stroke={props.axesColor}
-            gridVertical={props.gridVertical}
-            gridVerticalStroke={props.gridVerticalStroke}
-            gridVerticalStrokeWidth={props.gridVerticalStrokeWidth}
-            gridVerticalStrokeDash={props.gridVerticalStrokeDash}
-          />
-          <YAxis
-            yAxisClassName={props.yAxisClassName}
-            strokeWidth={props.yAxisStrokeWidth}
-            yScale={scales.yScale}
-            yAxisTickValues={props.yAxisTickValues}
-            yAxisTickCount={props.yAxisTickCount}
-            yAxisOffset={props.yAxisOffset}
-            yAxisLabel={props.yAxisLabel}
-            yAxisLabelOffset={props.yAxisLabelOffset}
-            tickFormatting={props.yAxisFormatter}
-            xOrient={props.xOrient}
-            yOrient={yOrient}
-            margins={svgMargins}
-            width={innerWidth}
-            height={innerHeight}
-            horizontalChart={props.horizontal}
-            stroke={props.axesColor}
-            gridHorizontal={props.gridHorizontal}
-            gridHorizontalStroke={props.gridHorizontalStroke}
-            gridHorizontalStrokeWidth={props.gridHorizontalStrokeWidth}
-            gridHorizontalStrokeDash={props.gridHorizontalStrokeDash}
-          />
-          <DataSeries
-            xScale={scales.xScale}
-            yScale={scales.yScale}
-            xAccessor={props.xAccessor}
-            yAccessor={props.yAccessor}
-            hoverAnimation={props.hoverAnimation}
-            circleRadius={props.circleRadius}
-            data={props.data}
-            value={allValues}
-            interpolationType={props.interpolationType}
-            colors={props.colors}
-            colorAccessor={props.colorAccessor}
-            width={innerWidth}
-            height={innerHeight}
+      <span onMouseLeave={this.onMouseLeave}>
+        <Chart
+          viewBox={this.getViewBox()}
+          legend={props.legend}
+          data={props.data}
+          margins={props.margins}
+          colors={props.colors}
+          colorAccessor={props.colorAccessor}
+          width={props.width}
+          height={props.height}
+          title={props.title}
+        >
+          <g transform={trans} className={props.className}>
+            <XAxis
+              xAxisClassName={props.xAxisClassName}
+              strokeWidth={props.xAxisStrokeWidth}
+              xAxisTickValues={props.xAxisTickValues}
+              xAxisTickInterval={props.xAxisTickInterval}
+              xAxisOffset={props.xAxisOffset}
+              xScale={scales.xScale}
+              xAxisLabel={props.xAxisLabel}
+              xAxisLabelOffset={props.xAxisLabelOffset}
+              tickFormatting={props.xAxisFormatter}
+              xOrient={props.xOrient}
+              yOrient={yOrient}
+              data={props.data}
+              margins={svgMargins}
+              width={innerWidth}
+              height={innerHeight}
+              horizontalChart={props.horizontal}
+              stroke={props.axesColor}
+              gridVertical={props.gridVertical}
+              gridVerticalStroke={props.gridVerticalStroke}
+              gridVerticalStrokeWidth={props.gridVerticalStrokeWidth}
+              gridVerticalStrokeDash={props.gridVerticalStrokeDash}
             />
-        </g>
-      </Chart>
+            <YAxis
+              yAxisClassName={props.yAxisClassName}
+              strokeWidth={props.yAxisStrokeWidth}
+              yScale={scales.yScale}
+              yAxisTickValues={props.yAxisTickValues}
+              yAxisTickCount={props.yAxisTickCount}
+              yAxisOffset={props.yAxisOffset}
+              yAxisLabel={props.yAxisLabel}
+              yAxisLabelOffset={props.yAxisLabelOffset}
+              tickFormatting={props.yAxisFormatter}
+              xOrient={props.xOrient}
+              yOrient={yOrient}
+              margins={svgMargins}
+              width={innerWidth}
+              height={innerHeight}
+              horizontalChart={props.horizontal}
+              stroke={props.axesColor}
+              gridHorizontal={props.gridHorizontal}
+              gridHorizontalStroke={props.gridHorizontalStroke}
+              gridHorizontalStrokeWidth={props.gridHorizontalStrokeWidth}
+              gridHorizontalStrokeDash={props.gridHorizontalStrokeDash}
+            />
+            <DataSeries
+              xScale={scales.xScale}
+              yScale={scales.yScale}
+              xAccessor={props.xAccessor}
+              yAccessor={props.yAccessor}
+              hoverAnimation={props.hoverAnimation}
+              circleRadius={props.circleRadius}
+              data={props.data}
+              value={allValues}
+              interpolationType={props.interpolationType}
+              colors={props.colors}
+              colorAccessor={props.colorAccessor}
+              width={innerWidth}
+              height={innerHeight}
+              onMouseOver={this.onMouseOver}
+              />
+          </g>
+        </Chart>
+        {(props.showTooltip ? <Tooltip {...this.state.tooltip}/> : null)}
+      </span>
     );
   }
 

--- a/src/linechart/VoronoiCircleContainer.jsx
+++ b/src/linechart/VoronoiCircleContainer.jsx
@@ -52,7 +52,9 @@ module.exports = React.createClass({
     );
   },
 
-  _animateCircle() {
+  _animateCircle(rect) {
+    var rect = this.getDOMNode().getElementsByTagName("circle")[0].getBoundingClientRect();
+    this.props.onMouseOver.call(this, rect.right, rect.top, this.props.dataPoint )
     this.setState({ 
       circleRadius: this.props.circleRadius * ( 5 / 4 ),
       circleFill: shade(this.props.circleFill, 0.2)

--- a/src/linechart/VoronoiCircleContainer.jsx
+++ b/src/linechart/VoronoiCircleContainer.jsx
@@ -52,7 +52,7 @@ module.exports = React.createClass({
     );
   },
 
-  _animateCircle(rect) {
+  _animateCircle() {
     var rect = this.getDOMNode().getElementsByTagName("circle")[0].getBoundingClientRect();
     this.props.onMouseOver.call(this, rect.right, rect.top, this.props.dataPoint )
     this.setState({ 

--- a/src/mixins/TooltipMixin.js
+++ b/src/mixins/TooltipMixin.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var React = require('react');
+
+module.exports =  {
+
+  propTypes: {
+    showTooltip:    React.PropTypes.bool,
+    tooltipFormat:  React.PropTypes.func
+  },
+
+  getDefaultProps() {
+    return {
+      showTooltip:   true,
+      tooltipFormat: (d) => d.yValue
+    };
+  },
+
+  getInitialState() {
+    return {
+      tooltip: {
+        cx: 0,
+        cy: 0,
+        text: '',
+        show: false
+      }
+    };
+  },
+
+  onMouseOver(cx, cy, dataPoint) {
+    if(!this.props.showTooltip)
+      return;
+    this.setState({
+      tooltip: {
+        cx: cx,
+        cy: cy,
+        text: this.props.tooltipFormat.call(this, dataPoint),
+        show: true 
+      } 
+    });
+  },
+
+  onMouseLeave() {
+    if(!this.props.showTooltip)
+      return;
+    this.setState({
+      tooltip: {
+        cx: 0,
+        cy: 0,
+        text: '',
+        show: false
+      } 
+    });
+  }
+}

--- a/src/mixins/TooltipMixin.js
+++ b/src/mixins/TooltipMixin.js
@@ -19,21 +19,21 @@ module.exports =  {
   getInitialState() {
     return {
       tooltip: {
-        cx: 0,
-        cy: 0,
+        x: 0,
+        y: 0,
         text: '',
         show: false
       }
     };
   },
 
-  onMouseOver(cx, cy, dataPoint) {
+  onMouseOver(x, y, dataPoint) {
     if(!this.props.showTooltip)
       return;
     this.setState({
       tooltip: {
-        cx: cx,
-        cy: cy,
+        x: x,
+        y: y,
         text: this.props.tooltipFormat.call(this, dataPoint),
         show: true 
       } 
@@ -45,8 +45,8 @@ module.exports =  {
       return;
     this.setState({
       tooltip: {
-        cx: 0,
-        cy: 0,
+        x: 0,
+        y: 0,
         text: '',
         show: false
       } 

--- a/src/mixins/TooltipMixin.js
+++ b/src/mixins/TooltipMixin.js
@@ -12,7 +12,7 @@ module.exports =  {
   getDefaultProps() {
     return {
       showTooltip:   true,
-      tooltipFormat: (d) => d.yValue
+      tooltipFormat: (d) => String(d.yValue)
     };
   },
 

--- a/src/mixins/TooltipMixin.js
+++ b/src/mixins/TooltipMixin.js
@@ -21,7 +21,7 @@ module.exports =  {
       tooltip: {
         x: 0,
         y: 0,
-        text: '',
+        child: '',
         show: false
       }
     };
@@ -34,7 +34,7 @@ module.exports =  {
       tooltip: {
         x: x,
         y: y,
-        text: this.props.tooltipFormat.call(this, dataPoint),
+        child: this.props.tooltipFormat.call(this, dataPoint),
         show: true 
       } 
     });
@@ -47,7 +47,7 @@ module.exports =  {
       tooltip: {
         x: 0,
         y: 0,
-        text: '',
+        child: '',
         show: false
       } 
     });

--- a/src/mixins/index.js
+++ b/src/mixins/index.js
@@ -2,3 +2,4 @@
 exports.CartesianChartPropsMixin = require('./CartesianChartPropsMixin');
 exports.DefaultAccessorsMixin = require('./DefaultAccessorsMixin');
 exports.ViewBoxMixin = require('./ViewBoxMixin');
+exports.TooltipMixin = require('./TooltipMixin');

--- a/src/piechart/ArcContainer.jsx
+++ b/src/piechart/ArcContainer.jsx
@@ -35,12 +35,15 @@ module.exports = React.createClass({
   },
 
   _animateArc() {
+    var rect = this.getDOMNode().getBoundingClientRect();
+    this.props.onMouseOver.call(this, rect.right, rect.top, this.props.dataPoint )
     this.setState({
       fill: shade(this.props.fill, 0.2)
     });
   },
 
   _restoreArc() {
+    this.props.onMouseLeave.call(this);
     this.setState({
       fill: this.props.fill
     });

--- a/src/piechart/DataSeries.jsx
+++ b/src/piechart/DataSeries.jsx
@@ -61,6 +61,9 @@ module.exports = React.createClass({
           showOuterLabels={props.showOuterLabels}
           sectorBorderColor={props.sectorBorderColor}
           hoverAnimation={props.hoverAnimation}
+          onMouseOver={props.onMouseOver}
+          onMouseLeave={props.onMouseLeave}
+          dataPoint={{yValue: props.values[idx]}}
         />
       );
     });

--- a/src/piechart/DataSeries.jsx
+++ b/src/piechart/DataSeries.jsx
@@ -63,7 +63,7 @@ module.exports = React.createClass({
           hoverAnimation={props.hoverAnimation}
           onMouseOver={props.onMouseOver}
           onMouseLeave={props.onMouseLeave}
-          dataPoint={{yValue: props.values[idx]}}
+          dataPoint={{yValue: props.values[idx], seriesName: props.labels[idx]}}
         />
       );
     });

--- a/src/piechart/PieChart.jsx
+++ b/src/piechart/PieChart.jsx
@@ -3,9 +3,12 @@
 var d3 = require('d3');
 var React = require('react');
 var DataSeries = require('./DataSeries');
-var Chart = require('../common').Chart;
+var { Chart, XAxis, YAxis, Tooltip} = require('../common');
+var TooltipMixin = require('../mixins').TooltipMixin;
 
 module.exports = React.createClass({
+
+  mixins: [ TooltipMixin ],
 
   displayName: 'PieChart',
 
@@ -46,33 +49,38 @@ module.exports = React.createClass({
     var labels = props.data.map( (item) => item.label );
 
     return (
-      <Chart
-        width={props.width}
-        height={props.height}
-        title={props.title}
-      >
-        <g className='rd3-piechart'>
-          <DataSeries
-            labelTextFill={props.labelTextFill}
-            valueTextFill={props.valueTextFill}
-            valueTextFormatter={props.valueTextFormatter}
-            data={props.data}
-            values={values}
-            labels={labels}
-            colors={props.colors}
-            colorAccessor={props.colorAccessor}
-            transform={transform}
-            width={props.width}
-            height={props.height}
-            radius={props.radius}
-            innerRadius={props.innerRadius}
-            showInnerLabels={props.showInnerLabels}
-            showOuterLabels={props.showOuterLabels}
-            sectorBorderColor={props.sectorBorderColor}
-            hoverAnimation={props.hoverAnimation}
-          />
-        </g>
-      </Chart>
+      <span>
+        <Chart
+          width={props.width}
+          height={props.height}
+          title={props.title}
+        >
+          <g className='rd3-piechart'>
+            <DataSeries
+              labelTextFill={props.labelTextFill}
+              valueTextFill={props.valueTextFill}
+              valueTextFormatter={props.valueTextFormatter}
+              data={props.data}
+              values={values}
+              labels={labels}
+              colors={props.colors}
+              colorAccessor={props.colorAccessor}
+              transform={transform}
+              width={props.width}
+              height={props.height}
+              radius={props.radius}
+              innerRadius={props.innerRadius}
+              showInnerLabels={props.showInnerLabels}
+              showOuterLabels={props.showOuterLabels}
+              sectorBorderColor={props.sectorBorderColor}
+              hoverAnimation={props.hoverAnimation}
+              onMouseOver={this.onMouseOver}
+              onMouseLeave={this.onMouseLeave}
+            />
+          </g>
+        </Chart>
+        {(props.showTooltip ? <Tooltip {...this.state.tooltip}/> : null)}
+      </span>
     );
   }
 

--- a/src/scatterchart/DataSeries.jsx
+++ b/src/scatterchart/DataSeries.jsx
@@ -70,7 +70,7 @@ module.exports = React.createClass({
           cy={cy}
           vnode={vnode}
           onMouseOver={props.onMouseOver}
-          dataPoint={{xValue: x, yValue: y}}
+          dataPoint={{xValue: x, yValue: y, seriesName: point.series.name}}
         />
       );
     });

--- a/src/scatterchart/DataSeries.jsx
+++ b/src/scatterchart/DataSeries.jsx
@@ -69,6 +69,8 @@ module.exports = React.createClass({
           cx={cx}
           cy={cy}
           vnode={vnode}
+          onMouseOver={props.onMouseOver}
+          dataPoint={{xValue: x, yValue: y}}
         />
       );
     });

--- a/src/scatterchart/ScatterChart.jsx
+++ b/src/scatterchart/ScatterChart.jsx
@@ -2,14 +2,14 @@
 
 var React = require('react');
 var d3 = require('d3');
-var { Chart, XAxis, YAxis } = require('../common');
+var { Chart, XAxis, YAxis, Tooltip} = require('../common');
 var DataSeries = require('./DataSeries');
 var utils = require('../utils');
-var { CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin } = require('../mixins');
+var { CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin, TooltipMixin } = require('../mixins');
 
 module.exports = React.createClass({
 
-  mixins: [ CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin ],
+  mixins: [ CartesianChartPropsMixin, DefaultAccessorsMixin, ViewBoxMixin, TooltipMixin ],
 
   displayName: 'ScatterChart',
 
@@ -63,82 +63,86 @@ module.exports = React.createClass({
     var yScale  = scales.yScale;
 
     return (
-      <Chart
-        colors={props.colors}
-        colorAccessor={props.colorAccessor}
-        data={data}
-        height={props.height}
-        legend={props.legend}
-        margins={props.margins}
-        title={props.title}
-        viewBox={this.getViewBox()}
-        width={props.width}
-      >
-        <g
-          className={props.className}
-          transform={trans}
+      <span onMouseLeave={this.onMouseLeave}>
+        <Chart
+          colors={props.colors}
+          colorAccessor={props.colorAccessor}
+          data={data}
+          height={props.height}
+          legend={props.legend}
+          margins={props.margins}
+          title={props.title}
+          viewBox={this.getViewBox()}
+          width={props.width}
         >
-          <XAxis
-            data={data}
-            height={innerHeight}
-            horizontalChart={props.horizontal}
-            margins={svgMargins}
-            stroke={props.axesColor}
-            strokeWidth={props.xAxisStrokeWidth.toString()}
-            tickFormatting={props.xAxisFormatter}
-            width={innerWidth}
-            xAxisClassName={props.xAxisClassName}
-            xAxisLabel={props.xAxisLabel}
-            xAxisLabelOffset={props.xAxisLabelOffset}
-            xAxisOffset={props.xAxisOffset}
-            xAxisTickInterval={props.xAxisTickInterval}
-            xAxisTickValues={props.xAxisTickValues}
-            xOrient={props.xOrient}
-            yOrient={yOrient}
-            xScale={xScale}
-            gridVertical={props.gridVertical}
-            gridVerticalStroke={props.gridVerticalStroke}
-            gridVerticalStrokeWidth={props.gridVerticalStrokeWidth}
-            gridVerticalStrokeDash={props.gridVerticalStrokeDash}
-          />
-          <YAxis
-            data={data}
-            width={innerWidth}
-            height={innerHeight}
-            horizontalChart={props.horizontal}
-            margins={svgMargins}
-            stroke={props.axesColor}
-            strokeWidth={props.yAxisStrokeWidth.toString()}
-            tickFormatting={props.yAxisFormatter}
-            yAxisClassName={props.yAxisClassName}
-            yAxisLabel={props.yAxisLabel}
-            yAxisLabelOffset={props.yAxisLabelOffset}
-            yAxisOffset={props.yAxisOffset}
-            yAxisTickValues={props.yAxisTickValues}
-            yAxisTickCount={props.yAxisTickCount}
-            yScale={yScale}
-            xOrient={props.xOrient}
-            yOrient={yOrient}
-            gridHorizontal={props.gridHorizontal}
-            gridHorizontalStroke={props.gridHorizontalStroke}
-            gridHorizontalStrokeWidth={props.gridHorizontalStrokeWidth}
-            gridHorizontalStrokeDash={props.gridHorizontalStrokeDash}
-          />
-          <DataSeries
-            circleRadius={props.circleRadius}
-            colors={props.colors}
-            colorAccessor={props.colorAccessor}
-            data={allValues}
-            height={innerHeight}
-            hoverAnimation={props.hoverAnimation}
-            width={innerWidth}
-            xAccessor={props.xAccessor}
-            xScale={xScale}
-            yAccessor={props.yAccessor}
-            yScale={yScale}
+          <g
+            className={props.className}
+            transform={trans}
+          >
+            <XAxis
+              data={data}
+              height={innerHeight}
+              horizontalChart={props.horizontal}
+              margins={svgMargins}
+              stroke={props.axesColor}
+              strokeWidth={props.xAxisStrokeWidth.toString()}
+              tickFormatting={props.xAxisFormatter}
+              width={innerWidth}
+              xAxisClassName={props.xAxisClassName}
+              xAxisLabel={props.xAxisLabel}
+              xAxisLabelOffset={props.xAxisLabelOffset}
+              xAxisOffset={props.xAxisOffset}
+              xAxisTickInterval={props.xAxisTickInterval}
+              xAxisTickValues={props.xAxisTickValues}
+              xOrient={props.xOrient}
+              yOrient={yOrient}
+              xScale={xScale}
+              gridVertical={props.gridVertical}
+              gridVerticalStroke={props.gridVerticalStroke}
+              gridVerticalStrokeWidth={props.gridVerticalStrokeWidth}
+              gridVerticalStrokeDash={props.gridVerticalStrokeDash}
             />
-        </g>
-      </Chart>
+            <YAxis
+              data={data}
+              width={innerWidth}
+              height={innerHeight}
+              horizontalChart={props.horizontal}
+              margins={svgMargins}
+              stroke={props.axesColor}
+              strokeWidth={props.yAxisStrokeWidth.toString()}
+              tickFormatting={props.yAxisFormatter}
+              yAxisClassName={props.yAxisClassName}
+              yAxisLabel={props.yAxisLabel}
+              yAxisLabelOffset={props.yAxisLabelOffset}
+              yAxisOffset={props.yAxisOffset}
+              yAxisTickValues={props.yAxisTickValues}
+              yAxisTickCount={props.yAxisTickCount}
+              yScale={yScale}
+              xOrient={props.xOrient}
+              yOrient={yOrient}
+              gridHorizontal={props.gridHorizontal}
+              gridHorizontalStroke={props.gridHorizontalStroke}
+              gridHorizontalStrokeWidth={props.gridHorizontalStrokeWidth}
+              gridHorizontalStrokeDash={props.gridHorizontalStrokeDash}
+            />
+            <DataSeries
+              circleRadius={props.circleRadius}
+              colors={props.colors}
+              colorAccessor={props.colorAccessor}
+              data={allValues}
+              height={innerHeight}
+              hoverAnimation={props.hoverAnimation}
+              width={innerWidth}
+              xAccessor={props.xAccessor}
+              xScale={xScale}
+              yAccessor={props.yAccessor}
+              yScale={yScale}
+              onMouseOver={this.onMouseOver}
+              />
+          </g>
+        </Chart>
+        {(props.showTooltip ? <Tooltip {...this.state.tooltip}/> : null)}
+      </span>
     );
   }
 

--- a/src/scatterchart/VoronoiCircleContainer.jsx
+++ b/src/scatterchart/VoronoiCircleContainer.jsx
@@ -37,13 +37,6 @@ module.exports = React.createClass({
     };
   },
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      circleFill:   nextProps.circleFill,
-      circleRadius: nextProps.circleRadius
-    });
-  },
-
   render() {
 
     var props = this.props;
@@ -68,9 +61,10 @@ module.exports = React.createClass({
 
   _animateCircle() {
     var props = this.props;
-    var rect = this.getDOMNode().getElementsByTagName("circle")[0].getBoundingClientRect();
-    this.props.onMouseOver.call(this, rect.right, rect.top, props.dataPoint )
+
     if(props.hoverAnimation) {
+      var rect = this.getDOMNode().getElementsByTagName("circle")[0].getBoundingClientRect();
+      this.props.onMouseOver.call(this, rect.right, rect.top, props.dataPoint )
       this.setState({
         circleFill:   shade(props.circleFill, props.shadeMultiplier),
         circleRadius: props.circleRadius * props.circleRadiusMultiplier

--- a/src/scatterchart/VoronoiCircleContainer.jsx
+++ b/src/scatterchart/VoronoiCircleContainer.jsx
@@ -68,7 +68,8 @@ module.exports = React.createClass({
 
   _animateCircle() {
     var props = this.props;
-
+    var rect = this.getDOMNode().getElementsByTagName("circle")[0].getBoundingClientRect();
+    this.props.onMouseOver.call(this, rect.right, rect.top, props.dataPoint )
     if(props.hoverAnimation) {
       this.setState({
         circleFill:   shade(props.circleFill, props.shadeMultiplier),
@@ -79,7 +80,6 @@ module.exports = React.createClass({
 
   _restoreCircle() {
     var props = this.props;
-
     if(props.hoverAnimation) {
       this.setState({
         circleFill:   props.circleFill,

--- a/tests/linechart-tests.js
+++ b/tests/linechart-tests.js
@@ -1,17 +1,17 @@
 'use strict';
 
 var expect = require('chai').expect;
+var React = require('react/addons');
+var LineChart = require('../src/linechart').LineChart;
+var generate = require('./utils/datagen').generateArrayOfPoints;
+var TestUtils = React.addons.TestUtils;
+var data, linechart;
+var length = 5;
 
 describe('LineChart', function() {
-  it('renders multi-series linechart with array of objects data', function() {
-    var React = require('react/addons');
-    var LineChart = require('../src/linechart').LineChart;
-    var generate = require('./utils/datagen').generateArrayOfPoints;
-    var TestUtils = React.addons.TestUtils;
-    var length = 5;
-
-    // Render a linechart using array data
-    var data = [
+  before(function() {
+    // Render a linechart
+    data = [
       {
         name: "series1",
         values: generate(length)
@@ -21,10 +21,13 @@ describe('LineChart', function() {
         values: generate(length)
       }
     ];
-    var linechart = TestUtils.renderIntoDocument(
+    linechart = TestUtils.renderIntoDocument(
       <LineChart data={data} width={400} height={200} />
     );
 
+  });
+
+  it('renders multi-series linechart with array of objects data', function() {
     // Verify that it has the same number of path as the array's length
     var paths = TestUtils.scryRenderedDOMComponentsWithClass(
       linechart, 'rd3-linechart-path');
@@ -33,5 +36,17 @@ describe('LineChart', function() {
     var circles = TestUtils.scryRenderedDOMComponentsWithClass(
       linechart, 'rd3-linechart-circle');
     expect(circles).to.have.length(Object.keys(data).length * length);
+  });
+
+  it('render tooltip when circle animates', function() {
+      var circle = TestUtils.scryRenderedDOMComponentsWithClass(
+        linechart, 'rd3-linechart-circle')[0];
+
+      // Before animation
+      expect(linechart.state.tooltip.show).to.equal(false);
+
+      // Animation starts with hover
+      TestUtils.Simulate.mouseOver(circle);
+      expect(linechart.state.tooltip.show).to.equal(true);
   });
 });

--- a/tests/scatterchart-tests.js
+++ b/tests/scatterchart-tests.js
@@ -100,4 +100,17 @@ describe('ScatterChart', function() {
 
   });
 
+  it('render tooltip when circle animates', function() {
+
+      var circle = TestUtils.scryRenderedDOMComponentsWithClass(
+        scatterchart, CIRCLE_CLASS_NAME)[0];
+
+      // Before animation
+      expect(scatterchart.state.tooltip.show).to.equal(false);
+
+      // Animation starts with hover
+      TestUtils.Simulate.mouseOver(circle);
+      expect(scatterchart.state.tooltip.show).to.equal(true);
+  });
+
 });


### PR DESCRIPTION
This new feature use the `TooltipMixin` to show a tooltip  when `onMouseOver` event is triggered. The charts that use this mixin (`LineChart`, `ScatterChart`, `BarChart` and `PieChart`) now support two new props: `showTooltip` (determines whether to use the tooltip) and `tooltipFormat` (a function that determines the tooltip text).
