### PR TITLE
Render voronoi geometry on top of linechart lines

### DIFF
--- a/src/linechart/DataSeries.jsx
+++ b/src/linechart/DataSeries.jsx
@@ -101,8 +101,8 @@ module.exports = React.createClass({
 
     return (
       <g>
-        <g>{regions}</g>
         <g>{lines}</g>
+        <g>{regions}</g>
       </g>
     );
   }


### PR DESCRIPTION
Currently the linechart line paths interfere with the hover animation by triggering mouse out events when the cursor goes on top of a line. This is a simple but effective fix, rendering the voronoi geometry (including the circles) on top of the lines.