### PR TITLE
Added phantomjs to package.json to allow npm test after npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "karma-phantomjs-launcher": "^0.2.0",
     "merge-stream": "^0.1.7",
     "mocha": "^2.2.5",
+    "phantomjs": "^2.1.3",
     "react-tools": "^0.13.3",
     "reactify": "^1.1.1",
     "uglify-js": "^2.4.23",


### PR DESCRIPTION
Without phantomjs in the package.json, I found that running `npm test` led to an error about missing phtanomjs package.